### PR TITLE
Make parsing of strings optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,27 @@
 #[macro_use]
 extern crate nom;
 
+pub trait FromByteResponse<'a> {
+    fn from_bytes(&'a [u8]) -> Self;
+}
+
+impl<'a> FromByteResponse<'a> for &'a str {
+    fn from_bytes(b: &'a [u8]) -> Self {
+        use std;
+        std::str::from_utf8(b).unwrap()
+    }
+}
+
+impl<'a> FromByteResponse<'a> for &'a [u8] {
+    fn from_bytes(b: &'a [u8]) -> Self {
+        b
+    }
+}
+
 pub mod builders;
 mod parser;
 pub mod types;
 
-pub use parser::{parse_response, ParseResult};
+pub use parser::ParseResult;
+pub use parser::{parse_response, parse_response_raw, parse_response_str};
 pub use types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use FromByteResponse;
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct Request(pub RequestId, pub Vec<u8>);
 
@@ -9,22 +11,48 @@ pub enum AttrMacro {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum Response<'a> {
-    Capabilities(Vec<&'a str>),
+pub enum Response<'a, T: FromByteResponse<'a>> {
+    Capabilities(Vec<T>),
     Done {
         tag: RequestId,
         status: Status,
-        code: Option<ResponseCode<'a>>,
-        information: Option<&'a str>,
+        code: Option<ResponseCode<T>>,
+        information: Option<T>,
     },
     Data {
         status: Status,
-        code: Option<ResponseCode<'a>>,
-        information: Option<&'a str>,
+        code: Option<ResponseCode<T>>,
+        information: Option<T>,
     },
     Expunge(u32),
-    Fetch(u32, Vec<AttributeValue<'a>>),
-    MailboxData(MailboxDatum<'a>),
+    Fetch(u32, Vec<AttributeValue<'a, T>>),
+    MailboxData(MailboxDatum<T>),
+}
+
+impl<'a> Response<'a, &'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> Response<'a, T> {
+        match self {
+            Response::Capabilities(v) => {
+                Response::Capabilities(v.into_iter().map(|c| T::from_bytes(c)).collect())
+            },
+            Response::Done { tag, status, code, information } => Response::Done {
+                tag,
+                status,
+                code: code.map(|rc| rc.map_bytes()),
+                information: information.map(|i| T::from_bytes(i)),
+            },
+            Response::Data { status, code, information } => Response::Data {
+                status,
+                code: code.map(|rc| rc.map_bytes()),
+                information: information.map(|i| T::from_bytes(i)),
+            },
+            Response::Expunge(e) => Response::Expunge(e),
+            Response::Fetch(t, a) => {
+                Response::Fetch(t, a.into_iter().map(|av| av.map_bytes()).collect())
+            },
+            Response::MailboxData(md) => Response::MailboxData(md.map_bytes()),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -37,9 +65,9 @@ pub enum Status {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum ResponseCode<'a> {
+pub enum ResponseCode<T> {
     HighestModSeq(u64), // RFC 4551, section 3.1.1
-    PermanentFlags(Vec<&'a str>),
+    PermanentFlags(Vec<T>),
     ReadOnly,
     ReadWrite,
     TryCreate,
@@ -48,22 +76,62 @@ pub enum ResponseCode<'a> {
     Unseen(u32),
 }
 
+impl<'a> ResponseCode<&'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> ResponseCode<T> {
+        match self {
+            ResponseCode::HighestModSeq(s) => ResponseCode::HighestModSeq(s),
+            ResponseCode::PermanentFlags(f) => {
+                ResponseCode::PermanentFlags(f.into_iter().map(|f| T::from_bytes(f)).collect())
+            },
+            ResponseCode::ReadOnly => ResponseCode::ReadOnly,
+            ResponseCode::ReadWrite => ResponseCode::ReadWrite,
+            ResponseCode::TryCreate => ResponseCode::TryCreate,
+            ResponseCode::UidNext(u) => ResponseCode::UidNext(u),
+            ResponseCode::UidValidity(v) => ResponseCode::UidValidity(v),
+            ResponseCode::Unseen(n) => ResponseCode::Unseen(n),
+        }
+    }
+}
+
 #[derive(Debug, Eq, PartialEq)]
-pub enum MailboxDatum<'a> {
+pub enum MailboxDatum<T> {
     Exists(u32),
-    Flags(Vec<&'a str>),
+    Flags(Vec<T>),
     List {
-        flags: Vec<&'a str>,
-        delimiter: &'a str,
-        name: &'a str,
+        flags: Vec<T>,
+        delimiter: T,
+        name: T,
     },
     SubList {
-        flags: Vec<&'a str>,
-        delimiter: &'a str,
-        name: &'a str,
+        flags: Vec<T>,
+        delimiter: T,
+        name: T,
     },
     Recent(u32),
 }
+
+impl<'a> MailboxDatum<&'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> MailboxDatum<T> {
+        match self {
+            MailboxDatum::Exists(e) => MailboxDatum::Exists(e),
+            MailboxDatum::Flags(f) => {
+                MailboxDatum::Flags(f.into_iter().map(|f| T::from_bytes(f)).collect())
+            },
+            MailboxDatum::List { flags, delimiter, name } => MailboxDatum::List {
+                flags: flags.into_iter().map(|f| T::from_bytes(f)).collect(),
+                delimiter: T::from_bytes(delimiter),
+                name: T::from_bytes(name),
+            },
+            MailboxDatum::SubList { flags, delimiter, name } => MailboxDatum::SubList {
+                flags: flags.into_iter().map(|f| T::from_bytes(f)).collect(),
+                delimiter: T::from_bytes(delimiter),
+                name: T::from_bytes(name),
+            },
+            MailboxDatum::Recent(r) => MailboxDatum::Recent(r),
+        }
+    }
+}
+
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Attribute {
@@ -91,41 +159,94 @@ pub enum SectionPath {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum AttributeValue<'a> {
+pub enum AttributeValue<'a, T: FromByteResponse<'a>> {
     BodySection {
         section: Option<SectionPath>,
         index: Option<u32>,
         data: Option<&'a [u8]>,
     },
-    Envelope(Envelope<'a>),
-    Flags(Vec<&'a str>),
-    InternalDate(&'a str),
+    Envelope(Envelope<T>),
+    Flags(Vec<T>),
+    InternalDate(T),
     ModSeq(u64), // RFC 4551, section 3.3.2
     Rfc822(Option<&'a [u8]>),
     Rfc822Size(u32),
     Uid(u32),
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct Envelope<'a> {
-    pub date: Option<&'a str>,
-    pub subject: Option<&'a str>,
-    pub from: Option<Vec<Address<'a>>>,
-    pub sender: Option<Vec<Address<'a>>>,
-    pub reply_to: Option<Vec<Address<'a>>>,
-    pub to: Option<Vec<Address<'a>>>,
-    pub cc: Option<Vec<Address<'a>>>,
-    pub bcc: Option<Vec<Address<'a>>>,
-    pub in_reply_to: Option<&'a str>,
-    pub message_id: Option<&'a str>,
+impl<'a> AttributeValue<'a, &'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> AttributeValue<'a, T> {
+        match self {
+            AttributeValue::BodySection { section, index, data } => {
+                AttributeValue::BodySection { section, index, data }
+            },
+            AttributeValue::Envelope(e) => AttributeValue::Envelope(e.map_bytes()),
+            AttributeValue::Flags(f) => {
+                AttributeValue::Flags(f.into_iter().map(|f| T::from_bytes(f)).collect())
+            },
+            AttributeValue::InternalDate(d) => AttributeValue::InternalDate(T::from_bytes(d)),
+            AttributeValue::ModSeq(ms) => AttributeValue::ModSeq(ms),
+            AttributeValue::Rfc822(b) => AttributeValue::Rfc822(b),
+            AttributeValue::Rfc822Size(s) => AttributeValue::Rfc822Size(s),
+            AttributeValue::Uid(u) => AttributeValue::Uid(u),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Address<'a> {
-    pub name: Option<&'a str>,
-    pub adl: Option<&'a str>,
-    pub mailbox: Option<&'a str>,
-    pub host: Option<&'a str>,
+pub struct Envelope<T> {
+    pub date: Option<T>,
+    pub subject: Option<T>,
+    pub from: Option<Vec<Address<T>>>,
+    pub sender: Option<Vec<Address<T>>>,
+    pub reply_to: Option<Vec<Address<T>>>,
+    pub to: Option<Vec<Address<T>>>,
+    pub cc: Option<Vec<Address<T>>>,
+    pub bcc: Option<Vec<Address<T>>>,
+    pub in_reply_to: Option<T>,
+    pub message_id: Option<T>,
+}
+
+impl<'a> Envelope<&'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> Envelope<T> {
+        Envelope {
+            date: self.date.map(|v| T::from_bytes(v)),
+            subject: self.subject.map(|v| T::from_bytes(v)),
+            from: self.from
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            sender: self.sender
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            reply_to: self.reply_to
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            to: self.to
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            cc: self.cc
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            bcc: self.bcc
+                .map(|addrs| addrs.into_iter().map(|a| a.map_bytes()).collect()),
+            in_reply_to: self.in_reply_to.map(|v| T::from_bytes(v)),
+            message_id: self.message_id.map(|v| T::from_bytes(v)),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Address<T> {
+    pub name: Option<T>,
+    pub adl: Option<T>,
+    pub mailbox: Option<T>,
+    pub host: Option<T>,
+}
+
+impl<'a> Address<&'a [u8]> {
+    pub(crate) fn map_bytes<T: FromByteResponse<'a>>(self) -> Address<T> {
+        Address {
+            name: self.name.map(|v| T::from_bytes(v)),
+            adl: self.adl.map(|v| T::from_bytes(v)),
+            mailbox: self.mailbox.map(|v| T::from_bytes(v)),
+            host: self.host.map(|v| T::from_bytes(v)),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This fixes #5 as proposed in that issue. Specifically, it introduces a trait, `FromByteResponse`, and provides a generic `parse_response` function that parses input as raw byte strings, and then maps them using some implementation of that trait. This in turns allows users to choose how they want to parse byte sequences in an ergonomic way.

Under the hood, this is *slightly* less efficient that it could be. Specifically, it parses everything as `&[u8]` first, and then maps everything using calls to `FromByteResponse`. This works fine, but will cause unnecessary re-allocation of vectors inside a bunch of structs. The way to work around this is to have `nom` directly use a generic return value in all its parsers, but this unfortunately doesn't seem to be supported at the time of writing.