### PR TITLE
[WIP] BODYSTRUCTURE FETCH response

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -97,6 +97,9 @@ pub enum AttributeValue<'a> {
         index: Option<u32>,
         data: Option<&'a [u8]>,
     },
+    Bodystructure {
+        data: Option<&'a [u8]>,
+    },
     Envelope(Envelope<'a>),
     Flags(Vec<&'a str>),
     InternalDate(&'a str),


### PR DESCRIPTION
Publication of very early state, just to make reviewing and collaboration easier. The `bodystructure` test still fails.

```
test parser::tests::bodystructure ... FAILED

failures:

---- parser::tests::bodystructure stdout ----
        thread 'parser::tests::bodystructure' panicked at 'unexpected response Error(Alt)', src/parser.rs:640:23
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    parser::tests::bodystructure
```