### PR TITLE
Add parsing for SEARCH response returning a Vector of IDs

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,6 +305,15 @@ named!(capability_data<Response>, do_parse!(
     (Response::Capabilities(capabilities))
 ));
 
+named!(search_data<Response>, do_parse!(
+    tag_s!("SEARCH") >>
+    ids: many0!(do_parse!(
+            tag_s!(" ") >>
+            id: number >>
+            (id))) >>
+    (Response::IDs(ids))
+));
+
 named!(mailbox_data_flags<Response>, do_parse!(
     tag_s!("FLAGS ") >>
     flags: flag_list >>
@@ -628,7 +637,8 @@ named!(response_data<Response>, do_parse!(
         mailbox_data |
         message_data_expunge |
         message_data_fetch |
-        capability_data
+        capability_data |
+        search_data
     ) >>
     tag_s!("\r\n") >>
     (contents)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,7 +305,7 @@ named!(capability_data<Response>, do_parse!(
     (Response::Capabilities(capabilities))
 ));
 
-named!(search_data<Response>, do_parse!(
+named!(mailbox_data_search<Response>, do_parse!(
     tag_s!("SEARCH") >>
     ids: many0!(do_parse!(
             tag_s!(" ") >>
@@ -414,7 +414,8 @@ named!(mailbox_data<Response>, alt!(
     mailbox_data_list |
     mailbox_data_lsub |
     mailbox_data_status |
-    mailbox_data_recent
+    mailbox_data_recent |
+    mailbox_data_search
 ));
 
 named!(nstring<Option<&[u8]>>, map!(
@@ -637,8 +638,7 @@ named!(response_data<Response>, do_parse!(
         mailbox_data |
         message_data_expunge |
         message_data_fetch |
-        capability_data |
-        search_data
+        capability_data
     ) >>
     tag_s!("\r\n") >>
     (contents)
@@ -705,6 +705,23 @@ mod tests {
                     StatusAttribute::Messages(231),
                     StatusAttribute::UidNext(44292),
                 ]);
+            },
+            rsp @ _ => panic!("unexpected response {:?}", rsp),
+        }
+    }
+
+    #[test]
+    fn test_search() {
+        match parse_response(b"* SEARCH\r\n") {
+            IResult::Done(_, Response::IDs(ids)) => {
+                assert!(ids.is_empty());
+            },
+            rsp @ _ => panic!("unexpected response {:?}", rsp),
+        }
+        match parse_response(b"* SEARCH 12345 67890\r\n") {
+            IResult::Done(_, Response::IDs(ids)) => {
+                assert_eq!(ids[0], 12345);
+                assert_eq!(ids[1], 67890);
             },
             rsp @ _ => panic!("unexpected response {:?}", rsp),
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,7 @@ pub enum Response<'a> {
     Expunge(u32),
     Fetch(u32, Vec<AttributeValue<'a>>),
     MailboxData(MailboxDatum<'a>),
+    IDs(Vec<u32>),
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
I wanted to handle the response to a [UID] SEARCH query via rust-imap, and added this to make it work. Not sure if this is the best / preferred way to do it, but I figured I would send it up and see what you thought.