### PR TITLE
Update capabilities

### DIFF
--- a/imap-proto/src/parser/rfc4551.rs
+++ b/imap-proto/src/parser/rfc4551.rs
@@ -12,26 +12,26 @@
 use core::number_64;
 use types::*;
 
-// The highest mod-sequence value of all messages in the mailbox.
-// Extends resp-test-code defined in rfc3501.
-// [RFC4551 - 3.6 HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
-// [RFC4551 - 4. Formal Syntax - resp-text-code](https://tools.ietf.org/html/rfc4551#section-4)
+/// The highest mod-sequence value of all messages in the mailbox.
+/// Extends resp-test-code defined in rfc3501.
+/// [RFC4551 - 3.6 HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
+/// [RFC4551 - 4. Formal Syntax - resp-text-code](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) resp_text_code_highest_mod_seq<ResponseCode>, do_parse!(
     tag_s!("HIGHESTMODSEQ ") >>
     num: number_64 >>
     (ResponseCode::HighestModSeq(num))
 ));
 
-// Extends status-att/status-att-list defined in rfc3501
-// [RFC4551 - 3.6 - HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
-// [RFC4551 - 4. Formal Syntax - status-att-val](https://tools.ietf.org/html/rfc4551#section-4)
+/// Extends status-att/status-att-list defined in rfc3501
+/// [RFC4551 - 3.6 - HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
+/// [RFC4551 - 4. Formal Syntax - status-att-val](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) status_att_val_highest_mod_seq<StatusAttribute>, do_parse!(
     tag_s!("HIGHESTMODSEQ ") >>
     mod_sequence_valzer: number_64 >>
     (StatusAttribute::HighestModSeq(mod_sequence_valzer))
 ));
 
-// [RFC4551 - 4. Formal Syntax - fetch-mod-resp](https://tools.ietf.org/html/rfc4551#section-4)
+/// [RFC4551 - 4. Formal Syntax - fetch-mod-resp](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) msg_att_mod_seq<AttributeValue>, do_parse!(
     tag_s!("MODSEQ (") >>
     num: number_64 >>

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -12,7 +12,7 @@ impl Copy for AttrMacro {}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Response<'a> {
-    Capabilities(Vec<&'a str>),
+    Capabilities(Vec<Capability<'a>>),
     Continue {
         code: Option<ResponseCode<'a>>,
         information: Option<&'a str>,
@@ -79,6 +79,14 @@ pub enum MailboxDatum<'a> {
         status: Vec<StatusAttribute>,
     },
     Recent(u32),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Capability<'a> {
+    IMAP4rev1,
+    /// Defined by [RFC2222 - SASL](https://tools.ietf.org/html/rfc2222)
+    Auth(&'a str),
+    Atom(&'a str),
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
- Enforces `IMAP4rev1`in capability-data.
```
"capability-data = CAPABILITY" *(SP capability) SP "IMAP4rev1" *(SP capability)
```
- Turn capability into enum type.
- Added tests

- Clean up cargo doc comments from previous merge request in rfc4551. Still can't see them when generating docs via `cargo doc --open --document-private-items -p imap-proto` still it's consistent. I assume this is due to nom macro magic.