### PR TITLE
NIL only parsed as literal in nstring

### DIFF
--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -82,9 +82,9 @@ named!(pub literal<&[u8]>, do_parse!(
 named!(pub string<&[u8]>, alt!(quoted | literal));
 
 /// nstring = string / nil
-named!(pub nstring<Option<&[u8]>>, map!(
-    alt!(tag_s!("NIL") | string),
-    |s| if s == b"NIL" { None } else { Some(s) }
+named!(pub nstring<Option<&[u8]>>, alt!(
+    map!(tag_s!("NIL"), |_| None) |
+    map!(string, |s| Some(s))
 ));
 
 /// number          = 1*DIGIT


### PR DESCRIPTION
As far as I can see from [RFC3501](https://tools.ietf.org/html/rfc3501#page-88) `nil`'s only possible value is a literal `NIL`, however is currently parsed as both a literal, and a quoted string in `nstring`.

This PR allows nil to be parsed only as a literal.