### PR TITLE
Refactor core

### DIFF
--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -105,16 +105,10 @@ named!(pub nstring_utf8<Option<&str>>, alt!(
 /// number          = 1*DIGIT
 ///                    ; Unsigned 32-bit integer
 ///                    ; (0 <= n < 4,294,967,296)
-named!(pub number<u32>, map_res!(
-    map_res!(nom::digit, str::from_utf8),
-    str::parse
-));
+named!(pub number<u32>, flat_map!(nom::digit, parse_to!(u32)));
 
 /// same as `number` but 64-bit
-named!(pub number_64<u64>, map_res!(
-    map_res!(nom::digit, str::from_utf8),
-    str::parse
-));
+named!(pub number_64<u64>, flat_map!(nom::digit, parse_to!(u64)));
 
 /// atom = 1*ATOM-CHAR
 named!(pub atom<&str>, map_res!(take_while1_s!(atom_char),

--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -34,6 +34,9 @@ pub fn atom_char(c: u8) -> bool {
     !atom_specials(c)
 }
 
+/// nil = "NIL"
+named!(pub nil, tag_s!("NIL"));
+
 /// ASTRING-CHAR = ATOM-CHAR / resp-specials
 pub fn astring_char(c: u8) -> bool {
     atom_char(c) || resp_specials(c)

--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -63,11 +63,10 @@ pub fn quoted_data(i: &[u8]) -> IResult<&[u8], &[u8]> {
 }
 
 /// quoted = DQUOTE *QUOTED-CHAR DQUOTE
-named!(pub quoted<&[u8]>, do_parse!(
-    tag_s!("\"") >>
-    data: quoted_data >>
-    tag_s!("\"") >>
-    (data)
+named!(pub quoted<&[u8]>, delimited!(
+    char!('"'),
+    quoted_data,
+    char!('"')
 ));
 
 /// quoted bytes as as utf8

--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -70,6 +70,9 @@ named!(pub quoted<&[u8]>, do_parse!(
     (data)
 ));
 
+/// quoted bytes as as utf8
+named!(pub quoted_utf8<&str>, map_res!(quoted, str::from_utf8));
+
 /// literal = "{" number "}" CRLF *CHAR8
 ///            ; Number represents the number of CHAR8s
 named!(pub literal<&[u8]>, do_parse!(
@@ -84,10 +87,19 @@ named!(pub literal<&[u8]>, do_parse!(
 /// string = quoted / literal
 named!(pub string<&[u8]>, alt!(quoted | literal));
 
+/// string bytes as as utf8
+named!(pub string_utf8<&str>, map_res!(string, str::from_utf8));
+
 /// nstring = string / nil
 named!(pub nstring<Option<&[u8]>>, alt!(
     map!(nil, |_| None) |
     map!(string, |s| Some(s))
+));
+
+/// nstring bytes as utf8
+named!(pub nstring_utf8<Option<&str>>, alt!(
+    map!(nil, |_| None) |
+    map!(string_utf8, |s| Some(s))
 ));
 
 /// number          = 1*DIGIT
@@ -114,6 +126,9 @@ named!(pub astring<&[u8]>, alt!(
     take_while1!(astring_char) |
     string
 ));
+
+/// astring bytes as as utf8
+named!(pub astring_utf8<&str>, map_res!(astring, str::from_utf8));
 
 /// text = 1*TEXT-CHAR
 named!(pub text<&str>, map_res!(take_while_s!(text_char),

--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -86,7 +86,7 @@ named!(pub string<&[u8]>, alt!(quoted | literal));
 
 /// nstring = string / nil
 named!(pub nstring<Option<&[u8]>>, alt!(
-    map!(tag_s!("NIL"), |_| None) |
+    map!(nil, |_| None) |
     map!(string, |s| Some(s))
 ));
 

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -47,7 +47,7 @@ named!(status<Status>, alt!(
 ));
 
 named!(mailbox<&str>, map!(
-    map_res!(astring, str::from_utf8),
+    astring_utf8,
     |s| {
         if s.eq_ignore_ascii_case("INBOX") {
             "INBOX"
@@ -101,10 +101,10 @@ named!(resp_text_code_badcharset<ResponseCode>, do_parse!(
     tag_s!("BADCHARSET") >>
     ch: opt!(do_parse!(
         tag_s!(" (") >>
-        charset0: map_res!(astring, str::from_utf8) >>
+        charset0: astring_utf8 >>
         charsets: many0!(do_parse!(
             tag_s!(" ") >>
-            charset: map_res!(astring, str::from_utf8) >>
+            charset: astring_utf8 >>
             (charset)
         )) >>
         tag_s!(")") >> ({
@@ -254,7 +254,7 @@ named!(mailbox_list<(Vec<&str>, Option<&str>, &str)>, do_parse!(
     flags: flag_list >>
     tag_s!(" ") >>
     delimiter: alt!(
-        map!(map_res!(quoted, str::from_utf8), |v| Some(v)) |
+        map!(quoted_utf8, |v| Some(v)) |
         map!(nil, |_| None)
     ) >>
     tag_s!(" ") >>
@@ -352,19 +352,19 @@ named!(mailbox_data<Response>, alt!(
 // electronic mail address.
 named!(address<Address>, do_parse!(
     tag_s!("(") >>
-    name: nstring >>
+    name: nstring_utf8 >>
     tag_s!(" ") >>
-    adl: nstring >>
+    adl: nstring_utf8 >>
     tag_s!(" ") >>
-    mailbox: nstring >>
+    mailbox: nstring_utf8 >>
     tag_s!(" ") >>
-    host: nstring >>
+    host: nstring_utf8 >>
     tag_s!(")") >>
     (Address {
-        name: name.map(|s| str::from_utf8(s).unwrap()),
-        adl: adl.map(|s| str::from_utf8(s).unwrap()),
-        mailbox: mailbox.map(|s| str::from_utf8(s).unwrap()),
-        host: host.map(|s| str::from_utf8(s).unwrap()),
+        name,
+        adl,
+        mailbox,
+        host,
     })
 ));
 
@@ -380,9 +380,9 @@ named!(opt_addresses<Option<Vec<Address>>>, alt!(
 
 named!(msg_att_envelope<AttributeValue>, do_parse!(
     tag_s!("ENVELOPE (") >>
-    date: nstring >>
+    date: nstring_utf8 >>
     tag_s!(" ") >>
-    subject: nstring >>
+    subject: nstring_utf8 >>
     tag_s!(" ") >>
     from: opt_addresses >>
     tag_s!(" ") >>
@@ -396,29 +396,29 @@ named!(msg_att_envelope<AttributeValue>, do_parse!(
     tag_s!(" ") >>
     bcc: opt_addresses >>
     tag_s!(" ") >>
-    in_reply_to: nstring >>
+    in_reply_to: nstring_utf8 >>
     tag_s!(" ") >>
-    message_id: nstring >>
+    message_id: nstring_utf8 >>
     tag_s!(")") >> ({
         AttributeValue::Envelope(Box::new(Envelope {
-            date: date.map(|s| str::from_utf8(s).unwrap()),
-            subject: subject.map(|s| str::from_utf8(s).unwrap()),
+            date,
+            subject,
             from,
             sender,
             reply_to,
             to,
             cc,
             bcc,
-            in_reply_to: in_reply_to.map(|s| str::from_utf8(s).unwrap()),
-            message_id: message_id.map(|s| str::from_utf8(s).unwrap()),
+            in_reply_to,
+            message_id,
         }))
     })
 ));
 
 named!(msg_att_internal_date<AttributeValue>, do_parse!(
     tag_s!("INTERNALDATE ") >>
-    date: nstring >>
-    (AttributeValue::InternalDate(str::from_utf8(date.unwrap()).unwrap()))
+    date: nstring_utf8 >>
+    (AttributeValue::InternalDate(date.unwrap()))
 ));
 
 named!(msg_att_flags<AttributeValue>, do_parse!(

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -255,7 +255,7 @@ named!(mailbox_list<(Vec<&str>, Option<&str>, &str)>, do_parse!(
     tag_s!(" ") >>
     delimiter: alt!(
         map!(map_res!(quoted, str::from_utf8), |v| Some(v)) |
-        map!(tag_s!("NIL"), |_| None)
+        map!(nil, |_| None)
     ) >>
     tag_s!(" ") >>
     name: mailbox >>
@@ -369,7 +369,7 @@ named!(address<Address>, do_parse!(
 ));
 
 named!(opt_addresses<Option<Vec<Address>>>, alt!(
-    map!(tag_s!("NIL"), |_s| None) |
+    map!(nil, |_s| None) |
     do_parse!(
         tag_s!("(") >>
         addrs: separated_nonempty_list!(opt!(tag!(" ")), address) >>


### PR DESCRIPTION
- Add `nil`.
- Add utf8 versions of `string`, `nstring`, `astring` and `quoted`.
- Simplify `number` and `number_64`.
- Used `delimited!` for `quoted`