### PR TITLE
Derive Hash for Capability enum

### DIFF
--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -85,7 +85,7 @@ pub enum MailboxDatum<'a> {
     Recent(u32),
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Capability<'a> {
     Imap4rev1,
     Auth(&'a str),


### PR DESCRIPTION
Required for use of Capability enumeration (recent PR https://github.com/djc/tokio-imap/pull/47)  in [rust-imap crate](https://github.com/jonhoo/rust-imap/blob/master/src/types/capabilities.rs#L34).