### PR TITLE
Fix regressions

### DIFF
--- a/imap-proto/src/macros.rs
+++ b/imap-proto/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! parenthesized_list (
         paren_delimited!($i, separated_list!(char!(' '), $submac!($($args)*)))
     });
     ($i:expr, $f:expr) => (
-        parenthesized_nonempty_list!($i, call!($f));
+        parenthesized_list!($i, call!($f));
     );
 );
 

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -316,7 +316,11 @@ named!(address<Address>, paren_delimited!(
 named!(opt_addresses<Option<Vec<Address>>>, alt!(
     map!(nil, |_s| None) |
     map!(paren_delimited!(
-        separated_nonempty_list!(opt!(char!(' ')), address)
+        many1!(do_parse!(
+            addr: address >>
+            opt!(char!(' ')) >>
+            (addr)
+        ))
     ), |v| Some(v))
 ));
 
@@ -665,6 +669,15 @@ mod tests {
     fn test_opt_addresses() {
         let addr = b"((NIL NIL \"minutes\" \"CNRI.Reston.VA.US\") (\"John Klensin\" NIL \"KLENSIN\" \"MIT.EDU\")) ";
             match ::parser::rfc3501::opt_addresses(addr) {
+            Ok((_, _addresses)) => {},
+            rsp @ _ => panic!("unexpected response {:?}", rsp)
+        }
+    }
+
+    #[test]
+    fn test_opt_addresses_no_space() {
+        let addr = br#"((NIL NIL "test" "example@example.com")(NIL NIL "test" "example@example.com"))"#;
+            match super::opt_addresses(addr) {
             Ok((_, _addresses)) => {},
             rsp @ _ => panic!("unexpected response {:?}", rsp)
         }


### PR DESCRIPTION
nom does not seem to be able to determine when the address list finishes with the optional space with the below combination of parsers.

```
paren_delimited!(separated_nonempty_list!(opt!(char!(' ')), address))
```

This PR adds a workaround, with an associated test that currently fails on master.

While checking the specification, I noticed a space is not specified anywhere in envelope addresses fields.
Not sure if the current behavior is against spec to accommodate a specific server?
```
address         = "(" addr-name SP addr-adl SP addr-mailbox SP addr-host ")"
env-bcc         = "(" 1*address ")" / nil
env-cc          = "(" 1*address ")" / nil
env-from        = "(" 1*address ")" / nil
env-reply-to    = "(" 1*address ")" / nil
env-sender      = "(" 1*address ")" / nil
env-to          = "(" 1*address ")" / nil
```