### PR TITLE
Upgrade to nom 5

### DIFF
--- a/imap-proto/Cargo.toml
+++ b/imap-proto/Cargo.toml
@@ -15,7 +15,7 @@ azure-devops = { project = "dochtman/Projects", pipeline = "tokio-imap", build =
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-nom = "4.0"
+nom = "5"
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/imap-proto/src/body.rs
+++ b/imap-proto/src/body.rs
@@ -4,7 +4,7 @@ use types::*;
 named!(pub section_part<Vec<u32>>, do_parse!(
     part: number >>
     rest: many0!(do_parse!(
-        tag_s!(".") >>
+        tag!(".") >>
         part: number >>
         (part)
     ))  >> ({
@@ -15,7 +15,7 @@ named!(pub section_part<Vec<u32>>, do_parse!(
 ));
 
 named!(pub section_msgtext<MessageSection>, map!(
-    alt!(tag_s!("HEADER") | tag_s!("TEXT")),
+    alt!(tag!("HEADER") | tag!("TEXT")),
     |s| match s {
         b"HEADER" => MessageSection::Header,
         b"TEXT" => MessageSection::Text,
@@ -25,7 +25,7 @@ named!(pub section_msgtext<MessageSection>, map!(
 
 named!(pub section_text<MessageSection>, alt!(
     section_msgtext |
-    do_parse!(tag_s!("MIME") >> (MessageSection::Mime))
+    do_parse!(tag!("MIME") >> (MessageSection::Mime))
 ));
 
 named!(pub section_spec<SectionPath>, alt!(
@@ -33,7 +33,7 @@ named!(pub section_spec<SectionPath>, alt!(
     do_parse!(
         part: section_part >>
         text: opt!(do_parse!(
-            tag_s!(".") >>
+            tag!(".") >>
             text: section_text >>
             (text)
         )) >>
@@ -42,22 +42,22 @@ named!(pub section_spec<SectionPath>, alt!(
 ));
 
 named!(pub section<Option<SectionPath>>, do_parse!(
-    tag_s!("[") >>
+    tag!("[") >>
     spec: opt!(section_spec) >>
-    tag_s!("]") >>
+    tag!("]") >>
     (spec)
 ));
 
 named!(pub msg_att_body_section<AttributeValue>, do_parse!(
-    tag_s!("BODY") >>
+    tag!("BODY") >>
     section: section >>
     index: opt!(do_parse!(
-        tag_s!("<") >>
+        tag!("<") >>
         num: number >>
-        tag_s!(">") >>
+        tag!(">") >>
         (num)
     )) >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     data: nstring >>
     (AttributeValue::BodySection { section, index, data })
 ));

--- a/imap-proto/src/body_structure.rs
+++ b/imap-proto/src/body_structure.rs
@@ -16,13 +16,13 @@ struct BodyFields<'a> {
 
 named!(body_fields<BodyFields>, do_parse!(
     param: body_param >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     id: nstring_utf8 >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     description: nstring_utf8 >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     transfer_encoding: body_encoding >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     octets: number >>
     (BodyFields { param, id, description, transfer_encoding, octets })
 ));
@@ -36,11 +36,11 @@ struct BodyExt1Part<'a> {
 }
 
 named!(body_ext_1part<BodyExt1Part>, do_parse!(
-    md5: opt_opt!(preceded!(tag_s!(" "), nstring_utf8)) >>
-    disposition: opt_opt!(preceded!(tag_s!(" "), body_disposition)) >>
-    language: opt_opt!(preceded!(tag_s!(" "), body_lang)) >>
-    location: opt_opt!(preceded!(tag_s!(" "), nstring_utf8)) >>
-    extension: opt!(preceded!(tag_s!(" "), body_extension)) >>
+    md5: opt_opt!(preceded!(tag!(" "), nstring_utf8)) >>
+    disposition: opt_opt!(preceded!(tag!(" "), body_disposition)) >>
+    language: opt_opt!(preceded!(tag!(" "), body_lang)) >>
+    location: opt_opt!(preceded!(tag!(" "), nstring_utf8)) >>
+    extension: opt!(preceded!(tag!(" "), body_extension)) >>
     (BodyExt1Part { md5, disposition, language, location, extension })
 ));
 
@@ -53,21 +53,21 @@ struct BodyExtMPart<'a> {
 }
 
 named!(body_ext_mpart<BodyExtMPart>, do_parse!(
-    param: opt_opt!(preceded!(tag_s!(" "), body_param)) >>
-    disposition: opt_opt!(preceded!(tag_s!(" "), body_disposition)) >>
-    language: opt_opt!(preceded!(tag_s!(" "), body_lang)) >>
-    location: opt_opt!(preceded!(tag_s!(" "), nstring_utf8)) >>
-    extension: opt!(preceded!(tag_s!(" "), body_extension)) >>
+    param: opt_opt!(preceded!(tag!(" "), body_param)) >>
+    disposition: opt_opt!(preceded!(tag!(" "), body_disposition)) >>
+    language: opt_opt!(preceded!(tag!(" "), body_lang)) >>
+    location: opt_opt!(preceded!(tag!(" "), nstring_utf8)) >>
+    extension: opt!(preceded!(tag!(" "), body_extension)) >>
     (BodyExtMPart { param, disposition, language, location, extension })
 ));
 
 named!(body_encoding<ContentEncoding>, alt!(
     delimited!(char!('"'), alt!(
-        map!(tag_no_case_s!("7BIT"), |_| ContentEncoding::SevenBit) |
-        map!(tag_no_case_s!("8BIT"), |_| ContentEncoding::EightBit) |
-        map!(tag_no_case_s!("BINARY"), |_| ContentEncoding::Binary) |
-        map!(tag_no_case_s!("BASE64"), |_| ContentEncoding::Base64) |
-        map!(tag_no_case_s!("QUOTED-PRINTABLE"), |_| ContentEncoding::QuotedPrintable)
+        map!(tag_no_case!("7BIT"), |_| ContentEncoding::SevenBit) |
+        map!(tag_no_case!("8BIT"), |_| ContentEncoding::EightBit) |
+        map!(tag_no_case!("BINARY"), |_| ContentEncoding::Binary) |
+        map!(tag_no_case!("BASE64"), |_| ContentEncoding::Base64) |
+        map!(tag_no_case!("QUOTED-PRINTABLE"), |_| ContentEncoding::QuotedPrintable)
     ), char!('"')) |
     map!(string_utf8, |enc| ContentEncoding::Other(enc))
 ));
@@ -81,7 +81,7 @@ named!(body_param<BodyParams>, alt!(
     map!(nil, |_| None) |
     map!(parenthesized_nonempty_list!(do_parse!(
         key: string_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         val: string_utf8 >>
         ((key, val))
     )), Option::from)
@@ -97,7 +97,7 @@ named!(body_disposition<Option<ContentDisposition>>, alt!(
     map!(nil, |_| None) |
     paren_delimited!(do_parse!(
         ty: string_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         params: body_param >>
         (Some(ContentDisposition {
             ty,
@@ -108,9 +108,9 @@ named!(body_disposition<Option<ContentDisposition>>, alt!(
 
 named!(body_type_basic<BodyStructure>, do_parse!(
     media_type: string_utf8 >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     media_subtype: string_utf8 >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     fields: body_fields >>
     ext: body_ext_1part >>
     (BodyStructure::Basic {
@@ -136,12 +136,12 @@ named!(body_type_basic<BodyStructure>, do_parse!(
 ));
 
 named!(body_type_text<BodyStructure>, do_parse!(
-    tag_no_case_s!("\"TEXT\"") >>
-    tag_s!(" ") >>
+    tag_no_case!("\"TEXT\"") >>
+    tag!(" ") >>
     media_subtype: string_utf8 >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     fields: body_fields >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     lines: number >>
     ext: body_ext_1part >>
     (BodyStructure::Text {
@@ -168,14 +168,14 @@ named!(body_type_text<BodyStructure>, do_parse!(
 ));
 
 named!(body_type_message<BodyStructure>, do_parse!(
-    tag_no_case_s!("\"MESSAGE\" \"RFC822\"") >>
-    tag_s!(" ") >>
+    tag_no_case!("\"MESSAGE\" \"RFC822\"") >>
+    tag!(" ") >>
     fields: body_fields >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     envelope: envelope >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     body: body >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     lines: number >>
     ext: body_ext_1part >>
     (BodyStructure::Message {
@@ -205,7 +205,7 @@ named!(body_type_message<BodyStructure>, do_parse!(
 
 named!(body_type_multipart<BodyStructure>, do_parse!(
     bodies: many1!(body) >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     media_subtype: string_utf8 >>
     ext: body_ext_mpart >>
     (BodyStructure::Multipart {
@@ -229,7 +229,7 @@ named!(pub(crate) body<BodyStructure>, paren_delimited!(
 ));
 
 named!(pub(crate) msg_att_body_structure<AttributeValue>, do_parse!(
-    tag_s!("BODYSTRUCTURE ") >>
+    tag!("BODYSTRUCTURE ") >>
     body: body >>
     (AttributeValue::BodyStructure(body))
 ));

--- a/imap-proto/src/core.rs
+++ b/imap-proto/src/core.rs
@@ -35,7 +35,7 @@ pub fn atom_char(c: u8) -> bool {
 }
 
 // nil = "NIL"
-named!(pub nil, tag_s!("NIL"));
+named!(pub nil, tag!("NIL"));
 
 // ASTRING-CHAR = ATOM-CHAR / resp-specials
 pub fn astring_char(c: u8) -> bool {
@@ -75,10 +75,10 @@ named!(pub quoted_utf8<&str>, map_res!(quoted, str::from_utf8));
 // literal = "{" number "}" CRLF *CHAR8
 //            ; Number represents the number of CHAR8s
 named!(pub literal<&[u8]>, do_parse!(
-    tag_s!("{") >>
+    tag!("{") >>
     len: number >>
-    tag_s!("}") >>
-    tag_s!("\r\n") >>
+    tag!("}") >>
+    tag!("\r\n") >>
     data: take!(len) >>
     (data)
 ));
@@ -104,13 +104,13 @@ named!(pub nstring_utf8<Option<&str>>, alt!(
 // number          = 1*DIGIT
 //                    ; Unsigned 32-bit integer
 //                    ; (0 <= n < 4,294,967,296)
-named!(pub number<u32>, flat_map!(nom::digit, parse_to!(u32)));
+named!(pub number<u32>, flat_map!(nom::character::complete::digit0, parse_to!(u32)));
 
 // same as `number` but 64-bit
-named!(pub number_64<u64>, flat_map!(nom::digit, parse_to!(u64)));
+named!(pub number_64<u64>, flat_map!(nom::character::complete::digit0, parse_to!(u64)));
 
 // atom = 1*ATOM-CHAR
-named!(pub atom<&str>, map_res!(take_while1_s!(atom_char),
+named!(pub atom<&str>, map_res!(take_while1!(atom_char),
     str::from_utf8
 ));
 
@@ -124,7 +124,7 @@ named!(pub astring<&[u8]>, alt!(
 named!(pub astring_utf8<&str>, map_res!(astring, str::from_utf8));
 
 // text = 1*TEXT-CHAR
-named!(pub text<&str>, map_res!(take_while_s!(text_char),
+named!(pub text<&str>, map_res!(take_while!(text_char),
     str::from_utf8
 ));
 

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -68,19 +68,19 @@ named!(flag<&str>, alt!(flag_extension | atom));
 named!(flag_list<Vec<&str>>, parenthesized_list!(flag));
 
 named!(flag_perm<&str>, alt!(
-    map_res!(tag_s!("\\*"), str::from_utf8) |
+    map_res!(tag!("\\*"), str::from_utf8) |
     flag
 ));
 
 named!(resp_text_code_alert<ResponseCode>, do_parse!(
-    tag_s!("ALERT") >>
+    tag!("ALERT") >>
     (ResponseCode::Alert)
 ));
 
 named!(resp_text_code_badcharset<ResponseCode>, do_parse!(
-    tag_s!("BADCHARSET") >>
+    tag!("BADCHARSET") >>
     ch: opt!(do_parse!(
-        tag_s!(" ") >>
+        tag!(" ") >>
         charsets: parenthesized_nonempty_list!(astring_utf8) >>
         (charsets)
     )) >>
@@ -93,51 +93,51 @@ named!(resp_text_code_capability<ResponseCode>, map!(
 ));
 
 named!(resp_text_code_parse<ResponseCode>, do_parse!(
-    tag_s!("PARSE") >>
+    tag!("PARSE") >>
     (ResponseCode::Parse)
 ));
 
 named!(resp_text_code_permanent_flags<ResponseCode>, do_parse!(
-    tag_s!("PERMANENTFLAGS ") >>
+    tag!("PERMANENTFLAGS ") >>
     flags: parenthesized_list!(flag_perm) >>
     (ResponseCode::PermanentFlags(flags))
 ));
 
 named!(resp_text_code_read_only<ResponseCode>, do_parse!(
-    tag_s!("READ-ONLY") >>
+    tag!("READ-ONLY") >>
     (ResponseCode::ReadOnly)
 ));
 
 named!(resp_text_code_read_write<ResponseCode>, do_parse!(
-    tag_s!("READ-WRITE") >>
+    tag!("READ-WRITE") >>
     (ResponseCode::ReadWrite)
 ));
 
 named!(resp_text_code_try_create<ResponseCode>, do_parse!(
-    tag_s!("TRYCREATE") >>
+    tag!("TRYCREATE") >>
     (ResponseCode::TryCreate)
 ));
 
 named!(resp_text_code_uid_validity<ResponseCode>, do_parse!(
-    tag_s!("UIDVALIDITY ") >>
+    tag!("UIDVALIDITY ") >>
     num: number >>
     (ResponseCode::UidValidity(num))
 ));
 
 named!(resp_text_code_uid_next<ResponseCode>, do_parse!(
-    tag_s!("UIDNEXT ") >>
+    tag!("UIDNEXT ") >>
     num: number >>
     (ResponseCode::UidNext(num))
 ));
 
 named!(resp_text_code_unseen<ResponseCode>, do_parse!(
-    tag_s!("UNSEEN ") >>
+    tag!("UNSEEN ") >>
     num: number >>
     (ResponseCode::Unseen(num))
 ));
 
 named!(resp_text_code<ResponseCode>, do_parse!(
-    tag_s!("[") >>
+    tag!("[") >>
     coded: alt!(
         resp_text_code_alert |
         resp_text_code_badcharset |
@@ -154,13 +154,13 @@ named!(resp_text_code<ResponseCode>, do_parse!(
     ) >>
     // Per the spec, the closing tag should be "] ".
     // See `resp_text` for more on why this is done differently.
-    tag_s!("]") >>
+    tag!("]") >>
     (coded)
 ));
 
 named!(capability<Capability>, alt!(
-    map!(tag_s!("IMAP4rev1"), |_| Capability::Imap4rev1) |
-    map!(preceded!(tag_s!("AUTH="), atom), |a| Capability::Auth(a)) |
+    map!(tag!("IMAP4rev1"), |_| Capability::Imap4rev1) |
+    map!(preceded!(tag!("AUTH="), atom), |a| Capability::Auth(a)) |
     map!(atom, |a| Capability::Atom(a))
 ));
 
@@ -174,7 +174,7 @@ fn ensure_capabilities_contains_imap4rev<'a>(capabilities: Vec<Capability<'a>>) 
 
 named!(capability_data<Vec<Capability>>, map_res!(
     do_parse!(
-        tag_s!("CAPABILITY") >>
+        tag!("CAPABILITY") >>
         capabilities: many0!(preceded!(char!(' '), capability)) >>
         (capabilities)
     ),
@@ -187,9 +187,9 @@ named!(resp_capability<Response>, map!(
 ));
 
 named!(mailbox_data_search<Response>, do_parse!(
-    tag_s!("SEARCH") >>
+    tag!("SEARCH") >>
     ids: many0!(do_parse!(
-        tag_s!(" ") >>
+        tag!(" ") >>
         id: number >>
         (id)
     )) >>
@@ -197,31 +197,31 @@ named!(mailbox_data_search<Response>, do_parse!(
 ));
 
 named!(mailbox_data_flags<Response>, do_parse!(
-    tag_s!("FLAGS ") >>
+    tag!("FLAGS ") >>
     flags: flag_list >>
     (Response::MailboxData(MailboxDatum::Flags(flags)))
 ));
 
 named!(mailbox_data_exists<Response>, do_parse!(
     num: number >>
-    tag_s!(" EXISTS") >>
+    tag!(" EXISTS") >>
     (Response::MailboxData(MailboxDatum::Exists(num)))
 ));
 
 named!(mailbox_list<(Vec<&str>, Option<&str>, &str)>, do_parse!(
     flags: flag_list >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     delimiter: alt!(
         map!(quoted_utf8, |v| Some(v)) |
         map!(nil, |_| None)
     ) >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     name: mailbox >>
     ((flags, delimiter, name))
 ));
 
 named!(mailbox_data_list<Response>, do_parse!(
-    tag_s!("LIST ") >>
+    tag!("LIST ") >>
     data: mailbox_list >>
     (Response::MailboxData(MailboxDatum::List {
         flags: data.0,
@@ -231,7 +231,7 @@ named!(mailbox_data_list<Response>, do_parse!(
 ));
 
 named!(mailbox_data_lsub<Response>, do_parse!(
-    tag_s!("LSUB ") >>
+    tag!("LSUB ") >>
     data: mailbox_list >>
     (Response::MailboxData(MailboxDatum::List {
         flags: data.0,
@@ -246,13 +246,13 @@ named!(status_att<StatusAttribute>, alt!(
     rfc4551::status_att_val_highest_mod_seq |
     do_parse!(
         key: alt!(
-            tag_s!("MESSAGES") |
-            tag_s!("RECENT") |
-            tag_s!("UIDNEXT") |
-            tag_s!("UIDVALIDITY") |
-            tag_s!("UNSEEN")
+            tag!("MESSAGES") |
+            tag!("RECENT") |
+            tag!("UIDNEXT") |
+            tag!("UIDVALIDITY") |
+            tag!("UNSEEN")
         ) >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         val: number >>
         (match key {
             b"MESSAGES" => StatusAttribute::Messages(val),
@@ -267,9 +267,9 @@ named!(status_att<StatusAttribute>, alt!(
 named!(status_att_list<Vec<StatusAttribute>>, parenthesized_nonempty_list!(status_att));
 
 named!(mailbox_data_status<Response>, do_parse!(
-    tag_s!("STATUS ") >>
+    tag!("STATUS ") >>
     mailbox: mailbox >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     status: status_att_list >>
     (Response::MailboxData(MailboxDatum::Status {
         mailbox,
@@ -279,7 +279,7 @@ named!(mailbox_data_status<Response>, do_parse!(
 
 named!(mailbox_data_recent<Response>, do_parse!(
     num: number >>
-    tag_s!(" RECENT") >>
+    tag!(" RECENT") >>
     (Response::MailboxData(MailboxDatum::Recent(num)))
 ));
 
@@ -298,11 +298,11 @@ named!(mailbox_data<Response>, alt!(
 named!(address<Address>, paren_delimited!(
     do_parse!(
         name: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         adl: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         mailbox: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         host: nstring_utf8 >>
         (Address {
             name,
@@ -327,23 +327,23 @@ named!(opt_addresses<Option<Vec<Address>>>, alt!(
 named!(pub(crate) envelope<Envelope>, paren_delimited!(
     do_parse!(
         date: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         subject: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         from: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         sender: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         reply_to: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         to: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         cc: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         bcc: opt_addresses >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         in_reply_to: nstring_utf8 >>
-        tag_s!(" ") >>
+        tag!(" ") >>
         message_id: nstring_utf8 >>
         (Envelope {
             date,
@@ -361,50 +361,50 @@ named!(pub(crate) envelope<Envelope>, paren_delimited!(
 ));
 
 named!(msg_att_envelope<AttributeValue>, do_parse!(
-    tag_s!("ENVELOPE ") >>
+    tag!("ENVELOPE ") >>
     envelope: envelope >>
     (AttributeValue::Envelope(Box::new(envelope)))
 ));
 
 named!(msg_att_internal_date<AttributeValue>, do_parse!(
-    tag_s!("INTERNALDATE ") >>
+    tag!("INTERNALDATE ") >>
     date: nstring_utf8 >>
     (AttributeValue::InternalDate(date.unwrap()))
 ));
 
 named!(msg_att_flags<AttributeValue>, do_parse!(
-    tag_s!("FLAGS ") >>
+    tag!("FLAGS ") >>
     flags: flag_list >>
     (AttributeValue::Flags(flags))
 ));
 
 named!(msg_att_rfc822<AttributeValue>, do_parse!(
-    tag_s!("RFC822 ") >>
+    tag!("RFC822 ") >>
     raw: nstring >>
     (AttributeValue::Rfc822(raw))
 ));
 
 named!(msg_att_rfc822_header<AttributeValue>, do_parse!(
-    tag_s!("RFC822.HEADER ") >>
-    opt!(tag_s!(" ")) >> // extra space workaround for DavMail
+    tag!("RFC822.HEADER ") >>
+    opt!(tag!(" ")) >> // extra space workaround for DavMail
     raw: nstring >>
     (AttributeValue::Rfc822Header(raw))
 ));
 
 named!(msg_att_rfc822_size<AttributeValue>, do_parse!(
-    tag_s!("RFC822.SIZE ") >>
+    tag!("RFC822.SIZE ") >>
     num: number >>
     (AttributeValue::Rfc822Size(num))
 ));
 
 named!(msg_att_rfc822_text<AttributeValue>, do_parse!(
-    tag_s!("RFC822.TEXT ") >>
+    tag!("RFC822.TEXT ") >>
     raw: nstring >>
     (AttributeValue::Rfc822Text(raw))
 ));
 
 named!(msg_att_uid<AttributeValue>, do_parse!(
-    tag_s!("UID ") >>
+    tag!("UID ") >>
     num: number >>
     (AttributeValue::Uid(num))
 ));
@@ -427,19 +427,19 @@ named!(msg_att_list<Vec<AttributeValue>>, parenthesized_nonempty_list!(msg_att))
 
 named!(message_data_fetch<Response>, do_parse!(
     num: number >>
-    tag_s!(" FETCH ") >>
+    tag!(" FETCH ") >>
     attrs: msg_att_list >>
     (Response::Fetch(num, attrs))
 ));
 
 named!(message_data_expunge<Response>, do_parse!(
     num: number >>
-    tag_s!(" EXPUNGE") >>
+    tag!(" EXPUNGE") >>
     (Response::Expunge(num))
 ));
 
 named!(tag<RequestId>, map!(
-    map_res!(take_while1_s!(tag_char), str::from_utf8),
+    map_res!(take_while1!(tag_char), str::from_utf8),
     |s| RequestId(s.to_string())
 ));
 
@@ -463,9 +463,9 @@ named!(resp_text<(Option<ResponseCode>, Option<&str>)>, do_parse!(
 ));
 
 named!(continue_req<Response>, do_parse!(
-    tag_s!("+ ") >>
+    tag!("+ ") >>
     text: resp_text >> // TODO: base64
-    tag_s!("\r\n") >>
+    tag!("\r\n") >>
     (Response::Continue {
         code: text.0,
         information: text.1,
@@ -474,11 +474,11 @@ named!(continue_req<Response>, do_parse!(
 
 named!(response_tagged<Response>, do_parse!(
     tag: tag >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     status: status >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     text: resp_text >>
-    tag_s!("\r\n") >>
+    tag!("\r\n") >>
     (Response::Done {
         tag,
         status,
@@ -489,7 +489,7 @@ named!(response_tagged<Response>, do_parse!(
 
 named!(resp_cond<Response>, do_parse!(
     status: status >>
-    tag_s!(" ") >>
+    tag!(" ") >>
     text: resp_text >>
     (Response::Data {
         status,
@@ -499,7 +499,7 @@ named!(resp_cond<Response>, do_parse!(
 ));
 
 named!(response_data<Response>, do_parse!(
-    tag_s!("* ") >>
+    tag!("* ") >>
     contents: alt!(
         resp_cond |
         mailbox_data |
@@ -507,7 +507,7 @@ named!(response_data<Response>, do_parse!(
         message_data_fetch |
         resp_capability
     ) >>
-    tag_s!("\r\n") >>
+    tag!("\r\n") >>
     (contents)
 ));
 

--- a/imap-proto/src/parser/rfc4551.rs
+++ b/imap-proto/src/parser/rfc4551.rs
@@ -17,7 +17,7 @@ use types::*;
 // [RFC4551 - 3.6 HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
 // [RFC4551 - 4. Formal Syntax - resp-text-code](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) resp_text_code_highest_mod_seq<ResponseCode>, do_parse!(
-    tag_s!("HIGHESTMODSEQ ") >>
+    tag!("HIGHESTMODSEQ ") >>
     num: number_64 >>
     (ResponseCode::HighestModSeq(num))
 ));
@@ -26,14 +26,14 @@ named!(pub (crate) resp_text_code_highest_mod_seq<ResponseCode>, do_parse!(
 // [RFC4551 - 3.6 - HIGHESTMODSEQ Status Data Items](https://tools.ietf.org/html/rfc4551#section-3.6)
 // [RFC4551 - 4. Formal Syntax - status-att-val](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) status_att_val_highest_mod_seq<StatusAttribute>, do_parse!(
-    tag_s!("HIGHESTMODSEQ ") >>
+    tag!("HIGHESTMODSEQ ") >>
     mod_sequence_valzer: number_64 >>
     (StatusAttribute::HighestModSeq(mod_sequence_valzer))
 ));
 
 // [RFC4551 - 4. Formal Syntax - fetch-mod-resp](https://tools.ietf.org/html/rfc4551#section-4)
 named!(pub (crate) msg_att_mod_seq<AttributeValue>, do_parse!(
-    tag_s!("MODSEQ ") >>
+    tag!("MODSEQ ") >>
     num: paren_delimited!(number_64) >>
     (AttributeValue::ModSeq(num))
 ));

--- a/tokio-imap/Cargo.toml
+++ b/tokio-imap/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.1"
 futures-state-stream = "0.1"
 imap-proto = { version = "0.8", path = "../imap-proto" }
 native-tls = "0.2"
-nom = "4.0"
+nom = "5"
 tokio = "0.1"
 tokio-codec = "0.1"
 tokio-tls = "0.2"

--- a/tokio-imap/examples/basic.rs
+++ b/tokio-imap/examples/basic.rs
@@ -95,7 +95,7 @@ impl Error for ImapError {
         ""
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ImapError::Connect { ref cause }
             | ImapError::Login { ref cause }

--- a/tokio-imap/src/proto.rs
+++ b/tokio-imap/src/proto.rs
@@ -49,10 +49,11 @@ impl<'a> Decoder for ImapCodec {
             Err(nom::Err::Incomplete(_)) => {
                 return Ok(None);
             }
-            Err(err) => {
+            Err(nom::Err::Error((_input, err_kind)))
+            | Err(nom::Err::Failure((_input, err_kind))) => {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
-                    format!("{} during parsing of {:?}", err, buf),
+                    format!("{:?} during parsing of {:?}", err_kind, buf),
                 ));
             }
         };


### PR DESCRIPTION
This takes care of a number of deprecation messages.

While nom 5 uses functions at its core instead of macros, the macros still work and this PR leaves the use of macros in place.