### PR TITLE
Add IMAP4REV1 test case

### DIFF
--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -790,6 +790,13 @@ mod tests {
         );
 
         assert_matches!(
+            super::capability_data(b"CAPABILITY IMAP4REV1\r\n"),
+            Ok((_, capabilities)) => {
+                assert_eq!(capabilities, vec![Capability::Imap4rev1])
+            }
+        );
+
+        assert_matches!(
             super::capability_data(b"CAPABILITY XPIG-LATIN IMAP4rev1 STARTTLS AUTH=GSSAPI\r\n"),
             Ok((_, capabilities)) => {
                 assert_eq!(capabilities, vec![


### PR DESCRIPTION
Test that "IMAP4rev1" capability is matched case-insensitive

See issue https://github.com/djc/tokio-imap/issues/54