### PR TITLE
Add IDLE capability and parse it

### DIFF
--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -161,6 +161,7 @@ named!(resp_text_code<ResponseCode>, do_parse!(
 
 named!(capability<Capability>, alt!(
     map!(tag_no_case!("IMAP4rev1"), |_| Capability::Imap4rev1) |
+    map!(tag_no_case!("IDLE"), |_| Capability::Idle) |
     map!(preceded!(tag_no_case!("AUTH="), atom), |a| Capability::Auth(a)) |
     map!(atom, |a| Capability::Atom(a))
 ));
@@ -848,7 +849,7 @@ mod tests {
                 information: None,
             })) => {}
             rsp @ _ => panic!("unexpected response {:?}", rsp)
-        }        
+        }
 
         // short version, sent by yandex
         match parse_response(b"+\r\n") {
@@ -857,6 +858,6 @@ mod tests {
                 information: None,
             })) => {}
             rsp @ _ => panic!("unexpected response {:?}", rsp)
-        }        
+        }
     }
 }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -104,6 +104,7 @@ pub enum Capability<'a> {
     Imap4rev1,
     Auth(&'a str),
     Atom(&'a str),
+    Idle
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
Added IDLE to the parsed capabilities (see https://tools.ietf.org/html/rfc2177).

I don't know if `parser/rfc3501.rs` was the correct place to do it, or if it is wanted at all, since the capability is part of another rfc.