### PR TITLE
Parse HEADER.FIELDS

### DIFF
--- a/imap-proto/src/body.rs
+++ b/imap-proto/src/body.rs
@@ -15,6 +15,12 @@ named!(pub section_part<Vec<u32>>, do_parse!(
 ));
 
 named!(pub section_msgtext<MessageSection>, alt!(
+    do_parse!(
+        tag_no_case!("HEADER.FIELDS") >>
+        opt!(tag_no_case!(".NOT")) >>
+        tag!(" ") >>
+        parenthesized_list!(astring) >>
+        (MessageSection::Header)) |
     do_parse!(tag_no_case!("HEADER") >> (MessageSection::Header)) |
     do_parse!(tag_no_case!("TEXT") >> (MessageSection::Text))
 ));

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -675,6 +675,16 @@ mod tests {
     }
 
     #[test]
+    fn test_header_fields() {
+        const RESPONSE: &[u8] = b"* 1 FETCH (UID 1 BODY[HEADER.FIELDS (CHAT-VERSION)] {21}\r\nChat-Version: 1.0\r\n\r\n)\r\n";
+
+        match parse_response(RESPONSE) {
+            Ok((_, Response::Fetch(_, _))) => {},
+            rsp => panic!("unexpected response {:?}", rsp),
+        }
+    }
+
+    #[test]
     fn test_opt_addresses() {
         let addr = b"((NIL NIL \"minutes\" \"CNRI.Reston.VA.US\") (\"John Klensin\" NIL \"KLENSIN\" \"MIT.EDU\")) ";
             match crate::parser::rfc3501::opt_addresses(addr) {


### PR DESCRIPTION
Currently [`HEADER.FIELDS` variant of `section-msgtext`](https://tools.ietf.org/html/rfc3501#page-89) is not handled at all.