### PR TITLE
Add RFC 5161 ENABLED response parser and test.

### DIFF
--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -5,6 +5,7 @@ pub mod core;
 
 pub mod rfc3501;
 pub mod rfc4551;
+pub mod rfc5161;
 pub mod rfc5464;
 
 pub type ParseResult<'a> = IResult<&'a [u8], Response<'a>>;

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -11,7 +11,7 @@ use std::str;
 
 use crate::{
     parser::{
-        core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4551, rfc5464::resp_metadata,
+        core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4551, rfc5161, rfc5464::resp_metadata,
         ParseResult,
     },
     types::*,
@@ -517,7 +517,8 @@ named!(response_data<Response>, do_parse!(
         message_data_expunge |
         message_data_fetch |
         resp_capability |
-        resp_metadata
+        resp_metadata |
+        rfc5161::resp_enabled
     ) >>
     tag!("\r\n") >>
     (contents)
@@ -932,6 +933,21 @@ mod tests {
                 },
             )) => {}
             rsp => panic!("unexpected response {:?}", rsp),
+        }
+    }
+
+    #[test]
+    fn test_enabled() {
+        match parse_response(b"* ENABLED QRESYNC X-GOOD-IDEA\r\n") {
+            Ok((_, capabilities)) => {
+                assert_eq!(capabilities,
+                    Response::Capabilities(vec![
+                        Capability::Atom("QRESYNC"),
+                        Capability::Atom("X-GOOD-IDEA"),
+                    ])
+                )
+            }
+            rsp => panic!("Unexpected response: {:?}", rsp),
         }
     }
 }

--- a/imap-proto/src/parser/rfc5161.rs
+++ b/imap-proto/src/parser/rfc5161.rs
@@ -1,0 +1,30 @@
+//!
+//! https://tools.ietf.org/html/rfc5161
+//!
+//! The IMAP ENABLE Extension
+//!
+
+// rustfmt doesn't do a very good job on nom parser invocations.
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
+
+use crate::types::*;
+use crate::parser::core::atom;
+
+// The ENABLED response lists capabilities that were enabled in response
+// to a ENABLE command.
+// [RFC5161 - 3.2 The ENABLED Response](https://tools.ietf.org/html/rfc5161#section-3.2)
+named!(pub (crate) resp_enabled<Response>, map!(
+    enabled_data,
+    |c| Response::Capabilities(c)
+));
+
+named!(enabled_data<Vec<Capability>>, do_parse!(
+        tag_no_case!("ENABLED") >>
+        capabilities: many0!(preceded!(char!(' '), capability)) >>
+        (capabilities)
+));
+
+named!(capability<Capability>,
+       map!(atom, |a| Capability::Atom(a))
+);


### PR DESCRIPTION
I needed this for parsing the response to 'ENABLE QRESYNC'.