### PR TITLE
Add workaround for Zoho Mail invalid FLAGS response

### DIFF
--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -70,7 +70,14 @@ fn flag(i: &[u8]) -> IResult<&[u8], &str> {
 }
 
 fn flag_list(i: &[u8]) -> IResult<&[u8], Vec<&str>> {
-    parenthesized_list(flag)(i)
+    // Correct code is
+    //   parenthesized_list(flag)(i)
+    //
+    // Unfortunately, Zoho Mail Server (imap.zoho.com) sends the following response:
+    // * FLAGS (\Answered \Flagged \Deleted \Seen \Draft \*)
+    //
+    // As a workaround, "\*" is allowed here.
+    parenthesized_list(flag_perm)(i)
 }
 
 fn flag_perm(i: &[u8]) -> IResult<&[u8], &str> {

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -316,3 +316,24 @@ fn test_enabled() {
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
 }
+
+#[test]
+fn test_flags() {
+    // Invalid response (FLAGS can't include \*) from Zoho Mail server.
+    //
+    // As a workaround, such response is parsed without error.
+    match parse_response(b"* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft \\*)\r\n") {
+        Ok((_, capabilities)) => assert_eq!(
+            capabilities,
+            Response::MailboxData(MailboxDatum::Flags(vec![
+                "\\Answered",
+                "\\Flagged",
+                "\\Deleted",
+                "\\Seen",
+                "\\Draft",
+                "\\*"
+            ]))
+        ),
+        rsp => panic!("Unexpected response: {:?}", rsp),
+    }
+}


### PR DESCRIPTION
imap.zoho.com server sends `\*` in FLAGS response, which is only allowed
in PERMANENTFLAGS list.

As a workaround, allow `\*` in FLAGS response and let the user interpret
the response.