### PR TITLE
Adding a `BodyStructParser`

### DIFF
--- a/imap-proto/src/parser/bodystructure.rs
+++ b/imap-proto/src/parser/bodystructure.rs
@@ -49,7 +49,7 @@ impl<'a> BodyStructParser<'a> {
                 }
             })
             .collect();
-        elem.first().and_then(|a| Some(a.to_vec()))
+        elem.first().map(|a| a.to_vec())
     }
 
     /// Reetr

--- a/imap-proto/src/parser/bodystructure.rs
+++ b/imap-proto/src/parser/bodystructure.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use crate::types::BodyStructure;
+/// An utility parser helping to find the appropriate
+/// section part from a FETCH response.
+pub struct BodyStructParser<'a> {
+    root: &'a BodyStructure<'a>,
+    prefix: Vec<u32>,
+    iter: u32,
+    map: HashMap<Vec<u32>, &'a BodyStructure<'a>>,
+}
+
+impl<'a> BodyStructParser<'a> {
+    /// Returns a new parser
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - The root of the `BodyStructure response.
+    pub fn new(root: &'a BodyStructure<'a>) -> Self {
+        let mut parser = BodyStructParser {
+            root,
+            prefix: vec![],
+            iter: 1,
+            map: HashMap::new(),
+        };
+
+        parser.parse(parser.root);
+        parser
+    }
+
+    /// Search particular element within the bodystructure.
+    ///
+    /// # Arguments
+    ///
+    /// * `func` - The filter used to search elements within the bodystructure.
+    pub fn search<F>(&self, func: F) -> Option<Vec<u32>>
+    where
+        F: Fn(&'a BodyStructure<'a>) -> bool,
+    {
+        let elem: Vec<_> = self
+            .map
+            .iter()
+            .filter_map(|(k, v)| {
+                if func(*v) {
+                    let slice: &[u32] = k;
+                    Some(slice)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        elem.first().and_then(|a| Some(a.to_vec()))
+    }
+
+    /// Reetr
+    fn parse(&mut self, node: &'a BodyStructure) {
+        match node {
+            BodyStructure::Multipart { bodies, .. } => {
+                let vec = self.prefix.clone();
+                self.map.insert(vec, node);
+
+                for (i, n) in bodies.iter().enumerate() {
+                    self.iter += i as u32;
+                    self.prefix.push(self.iter);
+                    self.parse(n);
+                    self.prefix.pop();
+                }
+                self.iter = 1;
+            }
+            _ => {
+                let vec = self.prefix.clone();
+                self.map.insert(vec, node);
+            }
+        };
+    }
+}

--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -3,6 +3,7 @@ use nom::{branch::alt, IResult};
 
 pub mod core;
 
+pub mod bodystructure;
 pub mod rfc3501;
 pub mod rfc4551;
 pub mod rfc5161;

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -1,4 +1,4 @@
-use super::parse_response;
+use super::{bodystructure::BodyStructParser, parse_response};
 use crate::types::*;
 
 #[test]
@@ -336,4 +336,34 @@ fn test_flags() {
         ),
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
+}
+
+#[test]
+fn test_imap_body_structure() {
+    let mut test = br#"* 1569 FETCH (BODYSTRUCTURE (((("TEXT" "PLAIN" ("CHARSET" "ISO-8859-1") NIL NIL "QUOTED-PRINTABLE" 833 30 NIL NIL NIL)("TEXT" "HTML" ("CHARSET" "ISO-8859-1") NIL NIL "QUOTED-PRINTABLE" 3412 62 NIL ("INLINE" NIL) NIL) "ALTERNATIVE" ("BOUNDARY" "2__=fgrths") NIL NIL)("IMAGE" "GIF" ("NAME" "485039.gif") "<2__=lgkfjr>" NIL "BASE64" 64 NIL ("INLINE" ("FILENAME" "485039.gif")) NIL) "RELATED" ("BOUNDARY" "1__=fgrths") NIL NIL)("APPLICATION" "PDF" ("NAME" "title.pdf") "<1__=lgkfjr>" NIL "BASE64" 333980 NIL ("ATTACHMENT" ("FILENAME" "title.pdf")) NIL) "MIXED" ("BOUNDARY" "0__=fgrths") NIL NIL))"#.to_vec();
+    test.extend_from_slice(b"\r\n");
+
+    let (_, resp) = parse_response(&test).unwrap();
+    match resp {
+        Response::Fetch(_, f) => {
+            let bodystructure = f
+                .iter()
+                .flat_map(|f| match f {
+                    AttributeValue::BodyStructure(e) => Some(e),
+                    _ => None,
+                })
+                .next()
+                .unwrap();
+
+            let parser = BodyStructParser::new(bodystructure);
+
+            let element = parser.search(|b: &BodyStructure| match *b {
+                BodyStructure::Basic { ref common, .. } if common.ty.ty == "APPLICATION" => true,
+                _ => false,
+            });
+
+            assert_eq!(element, Some(vec![2]));
+        }
+        _ => panic!("invalid FETCH command test"),
+    };
 }


### PR DESCRIPTION
Regarding #92, I propose to add an helper parser to be able to search out specific component from a `BodyStructure`. This will allow for example to retrieve the body section ID of some attachment from the BOPDYSTRUCTURE and perform a FETCH request in a second time to download only this specific element.