### PR TITLE
Add support for RFC7162 (QRESYNC) VANISHED response.

### DIFF
--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -7,6 +7,7 @@ pub mod rfc3501;
 pub mod rfc4551;
 pub mod rfc5161;
 pub mod rfc5464;
+pub mod rfc7162;
 
 #[cfg(test)]
 mod tests;

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -17,7 +17,9 @@ use nom::{
 };
 
 use crate::{
-    parser::{core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4551, rfc5161, rfc5464},
+    parser::{
+        core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4551, rfc5161, rfc5464, rfc7162,
+    },
     types::*,
 };
 
@@ -620,6 +622,7 @@ pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
             rfc5161::resp_enabled,
             rfc5464::metadata_solicited,
             rfc5464::metadata_unsolicited,
+            rfc7162::resp_vanished,
         )),
         tag(b"\r\n"),
     )(i)

--- a/imap-proto/src/parser/rfc7162.rs
+++ b/imap-proto/src/parser/rfc7162.rs
@@ -1,0 +1,36 @@
+//!
+//!
+//! https://tools.ietf.org/html/rfc7162
+//!
+//! The IMAP QRESYNC Extensions
+//!
+
+use nom::{
+    bytes::streaming::tag_no_case, character::streaming::space1, combinator::opt, sequence::tuple,
+    IResult,
+};
+
+use crate::parser::core::sequence_set;
+use crate::types::*;
+
+// The VANISHED response reports that the specified UIDs have been
+// permanently removed from the mailbox.  This response is similar to
+// the EXPUNGE response (RFC3501); however, it can return information
+// about multiple messages, and it returns UIDs instead of message
+// numbers.
+// [RFC7162 - VANISHED RESPONSE](https://tools.ietf.org/html/rfc7162#section-3.2.10)
+pub(crate) fn resp_vanished(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, earlier, _, uids)) = tuple((
+        tag_no_case("VANISHED"),
+        opt(tuple((space1, tag_no_case("(EARLIER)")))),
+        space1,
+        sequence_set,
+    ))(i)?;
+    Ok((
+        rest,
+        Response::Vanished {
+            earlier: earlier.is_some(),
+            uids,
+        },
+    ))
+}

--- a/imap-proto/src/types/mod.rs
+++ b/imap-proto/src/types/mod.rs
@@ -27,6 +27,10 @@ pub enum Response<'a> {
         information: Option<&'a str>,
     },
     Expunge(u32),
+    Vanished {
+        earlier: bool,
+        uids: Vec<std::ops::RangeInclusive<u32>>,
+    },
     Fetch(u32, Vec<AttributeValue<'a>>),
     MailboxData(MailboxDatum<'a>),
 }


### PR DESCRIPTION
RFC7162 defines a `VANISHED` response to the `EXPUNGE` command which must be used whenever a client has enabled `QRESYNC`. `VANISHED` may also appear in response to `SELECT/EXAMINE` or `UID FETCH`.

https://tools.ietf.org/html/rfc7162#section-3.2.10

The `VANISHED` response sends a sequence set of `UID`s indicating `UID`s which have been deleted from the mailbox.

I had to add parsers for `sequence-range` (eg `15:30`) and `sequence-set` (eg. `1,10:20,25,28:31`), and I put them in core.rs since they are actually defined in RFC 3501 and show up in a couple of other places, so may be generically useful.

I am not sure if the choice to return a `Vec<RangeInclusive>` is to your liking. Alternatives could be just a tuple of `(start, end)`, or expand the range out into a big list of `Vec<u32>`. I experimented with both options and settled on the `Vec<RangeInclusive>` because:

- It is literally how the spec defines them
- It is impossible to misinterpret, whereas a user would need to read the RFC to know `(start, end)` is inclusive
- It is efficient in that large ranges can be represented and iterated with low memory overhead.

The downside is it can be a bit awkward to use, since you end up iterating a list of iterators. Of course, the nicest way to represent this for the user is to expand the sequence set out into a `Vec<u32>`, but this could be wasteful / dangerous in some circumstances.