### PR TITLE
Allow trailing whitespace in search responses.

### DIFF
--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -207,7 +207,10 @@ fn capability_data(i: &[u8]) -> IResult<&[u8], Vec<Capability>> {
 
 fn mailbox_data_search(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
     map(
-        preceded(tag_no_case(b"SEARCH"), many0(preceded(tag(" "), number))),
+        terminated(
+            preceded(tag_no_case(b"SEARCH"), many0(preceded(tag(" "), number))),
+            opt(tag(" ")),
+        ),
         MailboxDatum::Search,
     )(i)
 }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -111,18 +111,23 @@ fn test_notify() {
 
 #[test]
 fn test_search() {
-    match parse_response(b"* SEARCH\r\n") {
-        Ok((_, Response::MailboxData(MailboxDatum::Search(ids)))) => {
-            assert!(ids.is_empty());
+    // also allow trailing whitespace in SEARCH responses
+    for empty_response in &["* SEARCH\r\n", "* SEARCH \r\n"] {
+        match parse_response(empty_response.as_bytes()) {
+            Ok((_, Response::MailboxData(MailboxDatum::Search(ids)))) => {
+                assert!(ids.is_empty());
+            }
+            rsp => panic!("unexpected response {:?}", rsp),
         }
-        rsp => panic!("unexpected response {:?}", rsp),
     }
-    match parse_response(b"* SEARCH 12345 67890\r\n") {
-        Ok((_, Response::MailboxData(MailboxDatum::Search(ids)))) => {
-            assert_eq!(ids[0], 12345);
-            assert_eq!(ids[1], 67890);
+    for response in &["* SEARCH 12345 67890\r\n", "* SEARCH 12345 67890 \r\n"] {
+        match parse_response(response.as_bytes()) {
+            Ok((_, Response::MailboxData(MailboxDatum::Search(ids)))) => {
+                assert_eq!(ids[0], 12345);
+                assert_eq!(ids[1], 67890);
+            }
+            rsp => panic!("unexpected response {:?}", rsp),
         }
-        rsp => panic!("unexpected response {:?}", rsp),
     }
 }
 


### PR DESCRIPTION
Hello! I have a small PR here to fix an issue I found in the wild. Let me know if I need to change anything about it!

This relates to #34.

While working on a project, I tried to connect to Yahoo's IMAP server,
and all SEARCH responses seemed to have a trailing whitespace. For
example in the case below, there is a whitespace (even though it might
not seem obvious) right after the last id:

```
C: a5 UID SEARCH ALL
S: * SEARCH 169654 169655 169656 169657 169658 169659 169660 169661
169662 169663 
```

I also happened to encounter this on empty SEARCH responses, which
led me to the issue linked above.