### PR TITLE
Avoid running the codecov.io CI without the token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    if: ${{ secrets && secrets.CODECOV_TOKEN }}
+    if: secrets && secrets.CODECOV_TOKEN
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,8 +70,8 @@ jobs:
           # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
           unset HAS_CODECOV_TOKEN
           # DO NOT SEND THIS BACK TO UPSTREAM WITHOUT REMOVING THE FOLLOWING LINE
-          printf 'CODECOV_TOKEN="%s"\n' $CODECOV_TOKEN
-          if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+          printf 'CODECOV_TOKEN="%s"\n' "$CODECOV_TOKEN"
+          if [ -n "$CODECOV_TOKEN" ]; then HAS_CODECOV_TOKEN='true' ; fi
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,13 @@ jobs:
           # see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>
           # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
           unset HAS_CODECOV_TOKEN
+          # DO NOT SEND THIS BACK TO UPSTREAM WITHOUT REMOVING THE FOLLOWING LINE
+          printf 'CODECOV_TOKEN="%s"\n' $CODECOV_TOKEN
           if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
         env:
-          CODECOV_TOKEN:  "${{ secrets.CODECOV_TOKEN }}"
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,6 @@ jobs:
           # see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>
           # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
           unset HAS_CODECOV_TOKEN
-          # DO NOT SEND THIS BACK TO UPSTREAM WITHOUT REMOVING THE FOLLOWING LINE
-          printf 'CODECOV_TOKEN="%s"\n' "$CODECOV_TOKEN"
           if [ -n "$CODECOV_TOKEN" ]; then HAS_CODECOV_TOKEN='true' ; fi
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,13 +69,11 @@ jobs:
           # see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>
           # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
           unset HAS_CODECOV_TOKEN
-          # DO NOT SEND THIS BACK TO UPSTREAM WITHOUT REMOVING THE FOLLOWING LINE
-          printf 'CODECOV_TOKEN="%s"\n' "$CODECOV_TOKEN"
           if [ -n "$CODECOV_TOKEN" ]; then HAS_CODECOV_TOKEN='true' ; fi
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
         env:
-          CODECOV_TOKEN: "let's force a success here to see where the problem is"  # "${{ secrets.CODECOV_TOKEN }}"
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    if: ${{secrets.CODECOV_TOKEN}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,8 @@ jobs:
           # see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>
           # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
           unset HAS_CODECOV_TOKEN
+          # DO NOT SEND THIS BACK TO UPSTREAM WITHOUT REMOVING THE FOLLOWING LINE
+          printf 'CODECOV_TOKEN="%s"\n' "$CODECOV_TOKEN"
           if [ -n "$CODECOV_TOKEN" ]; then HAS_CODECOV_TOKEN='true' ; fi
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    if: secrets && secrets.CODECOV_TOKEN
+    if: secrets
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    if: ${{secrets.CODECOV_TOKEN}}
+    if: ${{ secrets && secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
           echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
         env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+          CODECOV_TOKEN: "let's force a success here to see where the problem is"  # "${{ secrets.CODECOV_TOKEN }}"
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,21 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    if: secrets
     steps:
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          # check for CODECOV_TOKEN availability
+          # necessary to work around inaccessible 'secrets' object for 'if'
+          # see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>
+          # workaround from <https://github.com/rivy/rs.lsd/blob/a7b0ecdd022a061a59df41526cb7543e8ed82022/.github/workflows/CICD.yml#L287-L291>
+          unset HAS_CODECOV_TOKEN
+          if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+          echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+          echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+        env:
+          CODECOV_TOKEN:  "${{ secrets.CODECOV_TOKEN }}"
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -69,6 +82,8 @@ jobs:
           override: true
       - uses: actions-rs/tarpaulin@v0.1
       - uses: codecov/codecov-action@v1.0.2
+        # if: secrets.CODECOV_TOKEN (not supported {yet?}; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+        if: steps.vars.outputs.HAS_CODECOV_TOKEN
         with:
           token: ${{secrets.CODECOV_TOKEN}}
       - uses: actions/upload-artifact@v1

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -436,19 +436,4 @@ fn test_uidplus() {
         )) => {}
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
-
-    // TODO this panics:
-    // assert!(dbg!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n")).is_err())
-    // [imap-proto\src\parser\tests.rs:440] parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n") = Ok(
-    //     (
-    //         [],
-    //         Data {
-    //             status: Ok,
-    //             code: None,
-    //             information: Some(
-    //                 "[COPYUID 38505 304, 319:320 3956:3958] Done",
-    //             ),
-    //         },
-    //     ),
-    // )
 }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -439,7 +439,6 @@ fn test_uidplus() {
 
     // TODO this panics:
     // assert!(dbg!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n")).is_err())
-    //
     // [imap-proto\src\parser\tests.rs:440] parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n") = Ok(
     //     (
     //         [],

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -439,6 +439,7 @@ fn test_uidplus() {
 
     // TODO this panics:
     // assert!(dbg!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n")).is_err())
+    //
     // [imap-proto\src\parser\tests.rs:440] parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n") = Ok(
     //     (
     //         [],

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -436,4 +436,6 @@ fn test_uidplus() {
         )) => {}
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
+
+    assert!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err())
 }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -437,5 +437,8 @@ fn test_uidplus() {
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
 
-    assert!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err())
+    #[warn(clippy::todo)]
+    if parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err() {
+        todo!("this branch is supposed to be taken");
+    }
 }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -438,5 +438,17 @@ fn test_uidplus() {
     }
 
     // TODO this panics:
-    // assert!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err())
+    // assert!(dbg!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n")).is_err())
+    // [imap-proto\src\parser\tests.rs:440] parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n") = Ok(
+    //     (
+    //         [],
+    //         Data {
+    //             status: Ok,
+    //             code: None,
+    //             information: Some(
+    //                 "[COPYUID 38505 304, 319:320 3956:3958] Done",
+    //             ),
+    //         },
+    //     ),
+    // )
 }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -437,8 +437,6 @@ fn test_uidplus() {
         rsp => panic!("Unexpected response: {:?}", rsp),
     }
 
-    #[warn(clippy::todo)]
-    if parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err() {
-        todo!("this branch is supposed to be taken");
-    }
+    // TODO this panics:
+    // assert!(parse_response(b"* OK [COPYUID 38505 304, 319:320 3956:3958] Done\r\n").is_err())
 }


### PR DESCRIPTION
Unfortunately I have no idea how to test whether this actually works, other than sending in this PR and seeing what the CI does. And even that much, is assuming that CI will take into account the changes from this PR rather than just the repo.

~~EDIT: Oh. Huh. It doesn't run CI on PRs that don't contain any code changes. Makes sense, I suppose.~~

EDIT2: Wrong, see comment below.