### PR TITLE
Support for GETQUOTA response rfc2087

### DIFF
--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -4,6 +4,7 @@ use nom::{branch::alt, IResult};
 pub mod core;
 
 pub mod bodystructure;
+pub mod rfc2087;
 pub mod rfc3501;
 pub mod rfc4315;
 pub mod rfc4551;

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -197,13 +197,13 @@ mod tests {
         );
     }
 
-    fn terminated_qouta_root(i: &[u8]) -> IResult<&[u8], Response> {
+    fn terminated_quota_root(i: &[u8]) -> IResult<&[u8], Response> {
         nom::sequence::terminated(quota_root, nom::bytes::streaming::tag("\r\n"))(i)
     }
 
     #[test]
     fn test_quota_root_without_root_names() {
-        assert_matches! (terminated_qouta_root(b"QUOTAROOT comp.mail.mime\r\n") ,
+        assert_matches! (terminated_quota_root(b"QUOTAROOT comp.mail.mime\r\n") ,
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_quota_root2() {
         assert_matches! (
-            terminated_qouta_root(b"QUOTAROOT INBOX HU\r\n"),
+            terminated_quota_root(b"QUOTAROOT INBOX HU\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -232,7 +232,7 @@ mod tests {
         );
 
         assert_matches! (
-            terminated_qouta_root(b"QUOTAROOT INBOX \"\"\r\n"),
+            terminated_quota_root(b"QUOTAROOT INBOX \"\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -245,7 +245,7 @@ mod tests {
         );
 
         assert_matches! (
-            terminated_qouta_root(b"QUOTAROOT \"Inbox\" \"#Account\"\r\n"),
+            terminated_quota_root(b"QUOTAROOT \"Inbox\" \"#Account\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -258,7 +258,7 @@ mod tests {
         );
 
         assert_matches! (
-            terminated_qouta_root(b"QUOTAROOT \"Inbox\" \"#Account\" \"#Mailbox\"\r\n"),
+            terminated_quota_root(b"QUOTAROOT \"Inbox\" \"#Account\" \"#Mailbox\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -121,6 +121,25 @@ mod tests {
     }
 
     #[test]
+    fn test_quota_response_data() {
+        assert_matches! (crate::parser::rfc3501::response_data(b"* QUOTA \"\" (STORAGE 10 512)\r\n") ,
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::Quota(Quota {
+                        root_name: Cow::Borrowed(""),
+                        resources: vec![QuotaResource {
+                            name: QuotaResourceName::Storage,
+                            usage: 10,
+                            limit: 512
+                        }]
+                    })
+                );
+            }
+        );
+    }
+
+    #[test]
     fn test_quota_list() {
         assert_matches! (
             quota_list(b"(STORAGE 10 512)"),

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -166,8 +166,8 @@ mod tests {
     }
 
     #[test]
-    fn test_quota_root() {
-        assert_matches! (super::quota_root("QUOTAROOT INBOX \"\"".as_bytes()) ,
+    fn test_quota_root_response_data() {
+        assert_matches! (crate::parser::rfc3501::response_data("* QUOTAROOT INBOX \"\"\r\n".as_bytes()) ,
             Ok((_, r)) => {
                 assert_eq!(
                     r,

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -103,7 +103,8 @@ mod tests {
 
     #[test]
     fn test_quota() {
-        assert_matches! (quota(b"QUOTA \"\" (STORAGE 10 512)") ,
+        assert_matches!(
+            quota(b"QUOTA \"\" (STORAGE 10 512)"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -122,7 +123,8 @@ mod tests {
 
     #[test]
     fn test_quota_response_data() {
-        assert_matches! (crate::parser::rfc3501::response_data(b"* QUOTA \"\" (STORAGE 10 512)\r\n") ,
+        assert_matches!(
+            crate::parser::rfc3501::response_data(b"* QUOTA \"\" (STORAGE 10 512)\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -141,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_quota_list() {
-        assert_matches! (
+        assert_matches!(
             quota_list(b"(STORAGE 10 512)"),
             Ok((_, r)) => {
                 assert_eq!(
@@ -155,7 +157,8 @@ mod tests {
             }
         );
 
-        assert_matches! (quota_list(b"(MESSAGE 100 512)"),
+        assert_matches!(
+            quota_list(b"(MESSAGE 100 512)"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -168,7 +171,8 @@ mod tests {
             }
         );
 
-        assert_matches! (quota_list(b"(DAILY 55 200)"),
+        assert_matches!(
+            quota_list(b"(DAILY 55 200)"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -184,7 +188,8 @@ mod tests {
 
     #[test]
     fn test_quota_root_response_data() {
-        assert_matches! (crate::parser::rfc3501::response_data("* QUOTAROOT INBOX \"\"\r\n".as_bytes()) ,
+        assert_matches!(
+            crate::parser::rfc3501::response_data("* QUOTAROOT INBOX \"\"\r\n".as_bytes()),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -203,7 +208,8 @@ mod tests {
 
     #[test]
     fn test_quota_root_without_root_names() {
-        assert_matches! (terminated_quota_root(b"QUOTAROOT comp.mail.mime\r\n") ,
+        assert_matches!(
+            terminated_quota_root(b"QUOTAROOT comp.mail.mime\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
                     r,
@@ -218,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_quota_root2() {
-        assert_matches! (
+        assert_matches!(
             terminated_quota_root(b"QUOTAROOT INBOX HU\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
@@ -231,7 +237,7 @@ mod tests {
             }
         );
 
-        assert_matches! (
+        assert_matches!(
             terminated_quota_root(b"QUOTAROOT INBOX \"\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
@@ -244,7 +250,7 @@ mod tests {
             }
         );
 
-        assert_matches! (
+        assert_matches!(
             terminated_quota_root(b"QUOTAROOT \"Inbox\" \"#Account\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(
@@ -257,7 +263,7 @@ mod tests {
             }
         );
 
-        assert_matches! (
+        assert_matches!(
             terminated_quota_root(b"QUOTAROOT \"Inbox\" \"#Account\" \"#Mailbox\"\r\n"),
             Ok((_, r)) => {
                 assert_eq!(

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -1,0 +1,254 @@
+//!
+//! https://tools.ietf.org/html/rfc208 mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: ()7
+//!
+//! IMAP4 QUOTA extension
+//!
+
+use std::borrow::Cow;
+
+use nom::{
+    branch::alt,
+    bytes::streaming::{tag, tag_no_case},
+    character::streaming::space1,
+    combinator::map,
+    combinator::{eof, opt},
+    dbg_dmp,
+    multi::many0,
+    multi::{separated_list0, separated_list1},
+    sequence::{delimited, preceded, tuple},
+    IResult,
+};
+
+use crate::parser::core::astring_utf8;
+use crate::types::*;
+
+use super::core::number_64;
+
+/// 5.1. QUOTA Response
+/// ```ignore
+/// quota_response  ::= "QUOTA" SP astring SP quota_list
+/// ```
+pub(crate) fn quota(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, _, root_name, _, resources)) = tuple((
+        tag_no_case("QUOTA"),
+        space1,
+        map(astring_utf8, Cow::Borrowed),
+        space1,
+        quota_list,
+    ))(i)?;
+
+    Ok((
+        rest,
+        Response::Quota(Quota {
+            root_name,
+            resources,
+        }),
+    ))
+}
+
+/// ```ignore
+/// quota_list  ::= "(" #quota_resource ")"
+/// ```
+pub(crate) fn quota_list(i: &[u8]) -> IResult<&[u8], Vec<QuotaResource>> {
+    delimited(tag("("), separated_list0(space1, quota_resource), tag(")"))(i)
+}
+
+/// ```ignore
+/// quota_resource  ::= atom SP number SP number
+/// ```
+pub(crate) fn quota_resource(i: &[u8]) -> IResult<&[u8], QuotaResource> {
+    let (rest, (name, _, usage, _, limit)) = tuple((
+        quota_resource_name,
+        tag(" "),
+        number_64,
+        tag(" "),
+        number_64,
+    ))(i)?;
+
+    Ok((rest, QuotaResource { name, usage, limit }))
+}
+
+pub(crate) fn quota_resource_name(i: &[u8]) -> IResult<&[u8], QuotaResourceName> {
+    alt((
+        map(tag_no_case("STORAGE"), |_| QuotaResourceName::Storage),
+        map(tag_no_case("MESSAGE"), |_| QuotaResourceName::Message),
+        map(map(astring_utf8, Cow::Borrowed), QuotaResourceName::Atom),
+    ))(i)
+}
+
+/// 5.2. QUOTAROOT Response
+/// ```ignore
+/// quotaroot_response ::= "QUOTAROOT" SP astring *(SP astring)
+/// ```
+pub(crate) fn quota_root(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, _, mailbox_name, quota_root_names)) = tuple((
+        tag_no_case("QUOTAROOT"),
+        space1,
+        map(astring_utf8, Cow::Borrowed),
+        many0(preceded(space1, map(astring_utf8, Cow::Borrowed))),
+    ))(i)?;
+
+    Ok((
+        rest,
+        Response::QuotaRoot(QuotaRoot {
+            mailbox_name,
+            quota_root_names,
+        }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::*;
+    use assert_matches::assert_matches;
+    use std::borrow::Cow;
+
+    #[test]
+    fn test_quota() {
+        assert_matches! (super::quota(b"QUOTA \"\" (STORAGE 10 512)") ,
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::Quota(Quota {
+                        root_name: Cow::Borrowed(""),
+                        resources: vec![QuotaResource {
+                            name: QuotaResourceName::Storage,
+                            usage: 10,
+                            limit: 512
+                        }]
+                    })
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_quota_list() {
+        assert_matches! (
+            super::quota_list(b"(STORAGE 10 512)"),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    vec![QuotaResource {
+                        name: QuotaResourceName::Storage,
+                        usage: 10,
+                        limit: 512
+                    }]
+                );
+            }
+        );
+
+        assert_matches! (super::quota_list(b"(MESSAGE 100 512)"),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    vec![QuotaResource {
+                        name: QuotaResourceName::Message,
+                        usage: 100,
+                        limit: 512
+                    }]
+                );
+            }
+        );
+
+        assert_matches! ( super::quota_list(b"(DAILY 55 200)"),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    vec![QuotaResource {
+                        name: QuotaResourceName::Atom(Cow::Borrowed("DAILY")),
+                        usage: 55,
+                        limit: 200
+                    }]
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_quota_root() {
+        assert_matches! (super::quota_root("QUOTAROOT INBOX \"\"".as_bytes()) ,
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("INBOX"),
+                        quota_root_names: vec![Cow::Borrowed("")]
+                    })
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_quota_root_without_root_names() {
+        assert_matches! (super::quota_root(b"QUOTAROOT comp.mail.mime") ,
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("comp.mail.mime"),
+                        quota_root_names: vec![]
+                    })
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_quota_root2() {
+        assert_matches! (
+            super::quota_root(b"QUOTAROOT INBOX HU"),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("INBOX"),
+                        quota_root_names: vec![Cow::Borrowed("HU")]
+                    })
+                );
+            }
+        );
+
+        assert_matches! (
+            super::quota_root(b"QUOTAROOT INBOX \"\""),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("INBOX"),
+                        quota_root_names: vec![Cow::Borrowed("")]
+                    })
+                );
+            }
+        );
+
+        assert_matches! (
+            super::quota_root(b"QUOTAROOT \"Inbox\" \"#Account\""),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("INBOX"),
+                        quota_root_names: vec![Cow::Borrowed("#Account")]
+                    })
+                );
+            }
+        );
+
+        assert_matches! (
+            super::quota_root(b"QUOTAROOT \"Inbox\" \"#Account\" \"#Mailbox\""),
+            Ok((_, r)) => {
+                assert_eq!(
+                    r,
+                    Response::QuotaRoot(QuotaRoot{
+                        mailbox_name: Cow::Borrowed("INBOX"),
+                        quota_root_names: vec![Cow::Borrowed("#Account"), Cow::Borrowed("#Mailbox")]
+                    })
+                );
+            }
+        );
+    }
+
+    // TODO more tests
+}

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -11,10 +11,8 @@ use nom::{
     bytes::streaming::{tag, tag_no_case},
     character::streaming::space1,
     combinator::map,
-    combinator::{eof, opt},
-    dbg_dmp,
     multi::many0,
-    multi::{separated_list0, separated_list1},
+    multi::separated_list0,
     sequence::{delimited, preceded, tuple},
     IResult,
 };

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -1,5 +1,5 @@
 //!
-//! https://tools.ietf.org/html/rfc208 mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: () mailbox_name: (), quota_root_names: ()7
+//! https://tools.ietf.org/html/rfc2087
 //!
 //! IMAP4 QUOTA extension
 //!

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -20,7 +20,7 @@ use nom::{
 use crate::{
     parser::{
         core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551, rfc5161, rfc5256,
-        rfc5464, rfc7162,
+        rfc5464, rfc7162, rfc2087
     },
     types::*,
 };
@@ -629,7 +629,7 @@ fn resp_cond(i: &[u8]) -> IResult<&[u8], Response> {
 }
 
 // response-data   = "*" SP (resp-cond-state / resp-cond-bye /
-//                   mailbox-data / message-data / capability-data) CRLF
+//                   mailbox-data / message-data / capability-data / quota) CRLF
 pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
     delimited(
         tag(b"* "),
@@ -643,6 +643,8 @@ pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
             rfc5464::metadata_solicited,
             rfc5464::metadata_unsolicited,
             rfc7162::resp_vanished,
+            rfc2087::quota,
+            rfc2087::quota_root,
         )),
         tag(b"\r\n"),
     )(i)

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -189,6 +189,7 @@ fn resp_text_code(i: &[u8]) -> IResult<&[u8], ResponseCode> {
 fn capability(i: &[u8]) -> IResult<&[u8], Capability> {
     alt((
         map(tag_no_case(b"IMAP4rev1"), |_| Capability::Imap4rev1),
+        map(tag_no_case(b"QUOTA"), |_| Capability::Quota),
         map(
             map(preceded(tag_no_case(b"AUTH="), atom), Cow::Borrowed),
             Capability::Auth,
@@ -737,6 +738,15 @@ mod tests {
             Ok((_, capabilities)) => {
                 assert_eq!(capabilities, vec![
                     Capability::Imap4rev1, Capability::Auth(Cow::Borrowed("GSSAPI")),  Capability::Auth(Cow::Borrowed("PLAIN"))
+                ])
+            }
+        );
+
+        assert_matches!(
+            super::capability_data(b"CAPABILITY IMAP4rev1 AUTH=PLAIN QUOTA\r\n"),
+            Ok((_, capabilities)) => {
+                assert_eq!(capabilities, vec![
+                    Capability::Imap4rev1,  Capability::Auth(Cow::Borrowed("PLAIN")), Capability::Quota
                 ])
             }
         );

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -19,8 +19,8 @@ use nom::{
 
 use crate::{
     parser::{
-        core::*, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551, rfc5161, rfc5256,
-        rfc5464, rfc7162, rfc2087
+        core::*, rfc2087, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551, rfc5161,
+        rfc5256, rfc5464, rfc7162,
     },
     types::*,
 };

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -520,3 +520,23 @@ fn test_imap_body_structure() {
         _ => panic!("invalid FETCH command test"),
     };
 }
+
+#[test]
+fn test_parsing_of_quota_capability_in_login_response() {
+    match parse_response(b"* OK [CAPABILITY IMAP4rev1 IDLE QUOTA] Logged in\r\n") {
+        Ok((
+            _,
+            Response::Data {
+                status: Status::Ok,
+                code: Some(ResponseCode::Capabilities(c)),
+                information: Some(Cow::Borrowed("Logged in")),
+            },
+        )) => {
+            assert_eq!(c.len(), 3);
+            assert_eq!(c[0], Capability::Imap4rev1);
+            assert_eq!(c[1], Capability::Atom(Cow::Borrowed("IDLE")));
+            assert_eq!(c[2], Capability::Quota);
+        }
+        rsp => panic!("unexpected response {:?}", rsp),
+    }
+}

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -259,6 +259,7 @@ pub enum Capability<'a> {
     Imap4rev1,
     Auth(Cow<'a, str>),
     Atom(Cow<'a, str>),
+    Quota,
 }
 
 impl<'a> Capability<'a> {
@@ -267,6 +268,7 @@ impl<'a> Capability<'a> {
             Capability::Imap4rev1 => Capability::Imap4rev1,
             Capability::Auth(v) => Capability::Auth(to_owned_cow(v)),
             Capability::Atom(v) => Capability::Atom(to_owned_cow(v)),
+            Capability::Quota => Capability::Quota,
         }
     }
 }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -41,6 +41,8 @@ pub enum Response<'a> {
     },
     Fetch(u32, Vec<AttributeValue<'a>>),
     MailboxData(MailboxDatum<'a>),
+    Quota(Quota<'a>),
+    QuotaRoot(QuotaRoot<'a>),
 }
 
 impl<'a> Response<'a> {
@@ -87,6 +89,8 @@ impl<'a> Response<'a> {
                 attrs.into_iter().map(AttributeValue::into_owned).collect(),
             ),
             Response::MailboxData(datum) => Response::MailboxData(datum.into_owned()),
+            Response::Quota(quota) => Response::Quota(quota.into_owned()),
+            Response::QuotaRoot(quota_root) => Response::QuotaRoot(quota_root.into_owned()),
         }
     }
 }
@@ -696,6 +700,87 @@ impl<'a> BodyExtMPart<'a> {
                 .map(|v| v.into_iter().map(to_owned_cow).collect()),
             location: self.location.map(to_owned_cow),
             extension: self.extension.map(|v| v.into_owned()),
+        }
+    }
+}
+
+// IMAP4 QUOTA extension (rfc2087)
+
+/// https://tools.ietf.org/html/rfc2087#section-3
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum QuotaResourceName<'a> {
+    /// Sum of messages' RFC822.SIZE, in units of 1024 octets
+    Storage,
+    /// Number of messages
+    Message,
+    Atom(Cow<'a, str>),
+}
+
+impl<'a> QuotaResourceName<'a> {
+    pub fn into_owned(self) -> QuotaResourceName<'static> {
+        match self {
+            QuotaResourceName::Message => QuotaResourceName::Message,
+            QuotaResourceName::Storage => QuotaResourceName::Storage,
+            QuotaResourceName::Atom(v) => QuotaResourceName::Atom(to_owned_cow(v)),
+        }
+    }
+}
+
+/// 5.1. QUOTA Response (https://tools.ietf.org/html/rfc2087#section-5.1)
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct QuotaResource<'a> {
+    pub name: QuotaResourceName<'a>,
+    /// current usage of the resource
+    pub usage: u64,
+    /// resource limit
+    pub limit: u64,
+}
+
+impl<'a> QuotaResource<'a> {
+    pub fn into_owned(self) -> QuotaResource<'static> {
+        QuotaResource {
+            name: self.name.into_owned(),
+            usage: self.usage,
+            limit: self.limit,
+        }
+    }
+}
+
+/// 5.1. QUOTA Response (https://tools.ietf.org/html/rfc2087#section-5.1)
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct Quota<'a> {
+    /// quota root name
+    pub root_name: Cow<'a, str>,
+    pub resources: Vec<QuotaResource<'a>>,
+}
+
+impl<'a> Quota<'a> {
+    pub fn into_owned(self) -> Quota<'static> {
+        Quota {
+            root_name: to_owned_cow(self.root_name),
+            resources: self.resources.into_iter().map(|r| r.into_owned()).collect(),
+        }
+    }
+}
+
+/// 5.2. QUOTAROOT Response (https://tools.ietf.org/html/rfc2087#section-5.2)
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct QuotaRoot<'a> {
+    /// mailbox name
+    pub mailbox_name: Cow<'a, str>,
+    /// zero or more quota root names
+    pub quota_root_names: Vec<Cow<'a, str>>,
+}
+
+impl<'a> QuotaRoot<'a> {
+    pub fn into_owned(self) -> QuotaRoot<'static> {
+        QuotaRoot {
+            mailbox_name: to_owned_cow(self.mailbox_name),
+            quota_root_names: self
+                .quota_root_names
+                .into_iter()
+                .map(|r| to_owned_cow(r))
+                .collect(),
         }
     }
 }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -779,7 +779,7 @@ impl<'a> QuotaRoot<'a> {
             quota_root_names: self
                 .quota_root_names
                 .into_iter()
-                .map(|r| to_owned_cow(r))
+                .map(to_owned_cow)
                 .collect(),
         }
     }


### PR DESCRIPTION
### Idea / why?
I want that DeltaChat can warn me with a device message when my mailbox is running full.
I asked @link2xt about how I could accomplish this and the answer was that I need to implement parsing of the results into `imap-proto` first and then implement a function for it in `async-imap` before I can implement what I want into `deltachat-core`.

### To Do:
- [X] QUOTA Response
- [x] Fix QUOTAROOT Response parsing tests (help wanted, I'm unable to fix this on my own right-now, nom complains about incomplete input, testing via `crate::parser::rfc3501::response_data` on the other hand works, only testing the standalone function makes problems)

_As I don't really understand completely what I need to do / am doing here, please review it carefully._