### PR TITLE
add derive clone to quota structs/types

### DIFF
--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -708,7 +708,7 @@ impl<'a> BodyExtMPart<'a> {
 // IMAP4 QUOTA extension (rfc2087)
 
 /// https://tools.ietf.org/html/rfc2087#section-3
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum QuotaResourceName<'a> {
     /// Sum of messages' RFC822.SIZE, in units of 1024 octets
     Storage,
@@ -728,7 +728,7 @@ impl<'a> QuotaResourceName<'a> {
 }
 
 /// 5.1. QUOTA Response (https://tools.ietf.org/html/rfc2087#section-5.1)
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct QuotaResource<'a> {
     pub name: QuotaResourceName<'a>,
     /// current usage of the resource
@@ -748,7 +748,7 @@ impl<'a> QuotaResource<'a> {
 }
 
 /// 5.1. QUOTA Response (https://tools.ietf.org/html/rfc2087#section-5.1)
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct Quota<'a> {
     /// quota root name
     pub root_name: Cow<'a, str>,
@@ -765,7 +765,7 @@ impl<'a> Quota<'a> {
 }
 
 /// 5.2. QUOTAROOT Response (https://tools.ietf.org/html/rfc2087#section-5.2)
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct QuotaRoot<'a> {
     /// mailbox name
     pub mailbox_name: Cow<'a, str>,


### PR DESCRIPTION
I think that's the last thing I needed to do in `imap-proto` for get-quota support.

PS: a new 1.14.3 release of imap-proto including this would be awesome :innocent:  :tada: