### PR TITLE
Add special-use mailboxes name attributes

### DIFF
--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -245,10 +245,12 @@ fn mailbox_data_exists(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
 
 fn name_attribute(i: &[u8]) -> IResult<&[u8], NameAttribute> {
     alt((
+        // RFC 3501
         value(NameAttribute::NoInferiors, tag_no_case(b"\\Noinferiors")),
         value(NameAttribute::NoSelect, tag_no_case(b"\\Noselect")),
         value(NameAttribute::Marked, tag_no_case(b"\\Marked")),
         value(NameAttribute::Unmarked, tag_no_case(b"\\Unmarked")),
+        // RFC 6154
         value(NameAttribute::All, tag_no_case(b"\\All")),
         value(NameAttribute::Archive, tag_no_case(b"\\Archive")),
         value(NameAttribute::Drafts, tag_no_case(b"\\Drafts")),
@@ -256,6 +258,7 @@ fn name_attribute(i: &[u8]) -> IResult<&[u8], NameAttribute> {
         value(NameAttribute::Junk, tag_no_case(b"\\Junk")),
         value(NameAttribute::Sent, tag_no_case(b"\\Sent")),
         value(NameAttribute::Trash, tag_no_case(b"\\Trash")),
+        // Extensions not supported by this crate
         map(
             map_res(
                 recognize(pair(tag(b"\\"), take_while(is_atom_char))),

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -249,6 +249,13 @@ fn name_attribute(i: &[u8]) -> IResult<&[u8], NameAttribute> {
         value(NameAttribute::NoSelect, tag_no_case(b"\\Noselect")),
         value(NameAttribute::Marked, tag_no_case(b"\\Marked")),
         value(NameAttribute::Unmarked, tag_no_case(b"\\Unmarked")),
+        value(NameAttribute::All, tag_no_case(b"\\All")),
+        value(NameAttribute::Archive, tag_no_case(b"\\Archive")),
+        value(NameAttribute::Drafts, tag_no_case(b"\\Drafts")),
+        value(NameAttribute::Flagged, tag_no_case(b"\\Flagged")),
+        value(NameAttribute::Junk, tag_no_case(b"\\Junk")),
+        value(NameAttribute::Sent, tag_no_case(b"\\Sent")),
+        value(NameAttribute::Trash, tag_no_case(b"\\Trash")),
         map(
             map_res(
                 recognize(pair(tag(b"\\"), take_while(is_atom_char))),

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -27,10 +27,12 @@ fn test_name_attributes() {
             assert_eq!(
                 name_attributes,
                 vec![
+                    // RFC 3501
                     NameAttribute::NoInferiors,
                     NameAttribute::NoSelect,
                     NameAttribute::Marked,
                     NameAttribute::Unmarked,
+                    // RFC 6154
                     NameAttribute::All,
                     NameAttribute::Archive,
                     NameAttribute::Drafts,
@@ -38,6 +40,7 @@ fn test_name_attributes() {
                     NameAttribute::Junk,
                     NameAttribute::Sent,
                     NameAttribute::Trash,
+                    // Extensions not supported by this crate
                     NameAttribute::Extension(Cow::Borrowed("\\Foobar")),
                 ]
             );

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -16,7 +16,7 @@ fn test_mailbox_data_response() {
 #[test]
 fn test_name_attributes() {
     match parse_response(
-        b"* LIST (\\Noinferiors \\Noselect \\Marked \\Unmarked \\Foobar) \".\" INBOX.Tests\r\n",
+        b"* LIST (\\Noinferiors \\Noselect \\Marked \\Unmarked \\All \\Archive \\Drafts \\Flagged \\Junk \\Sent \\Trash \\Foobar) \".\" INBOX.Tests\r\n",
     ) {
         Ok((
             _,
@@ -31,6 +31,13 @@ fn test_name_attributes() {
                     NameAttribute::NoSelect,
                     NameAttribute::Marked,
                     NameAttribute::Unmarked,
+                    NameAttribute::All,
+                    NameAttribute::Archive,
+                    NameAttribute::Drafts,
+                    NameAttribute::Flagged,
+                    NameAttribute::Junk,
+                    NameAttribute::Sent,
+                    NameAttribute::Trash,
                     NameAttribute::Extension(Cow::Borrowed("\\Foobar")),
                 ]
             );

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -716,6 +716,9 @@ impl<'a> BodyExtMPart<'a> {
 
 /// The name attributes are returned as part of a LIST response described in
 /// [RFC 3501 section 7.2.2](https://tools.ietf.org/html/rfc3501#section-7.2.2).
+///
+/// This enumeration additional includes values from the extension Special-Use
+/// Mailboxes [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2).
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[non_exhaustive]
 pub enum NameAttribute<'a> {
@@ -740,6 +743,62 @@ pub enum NameAttribute<'a> {
     /// > The mailbox does not contain any additional messages since the
     /// > last time the mailbox was selected.
     Unmarked,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox presents all messages in the user's message store.
+    /// > Implementations MAY omit some messages, such as, perhaps, those
+    /// > in \Trash and \Junk.  When this special use is supported, it is
+    /// > almost certain to represent a virtual mailbox.
+    All,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox is used to archive messages.  The meaning of an
+    /// > "archival" mailbox is server-dependent; typically, it will be
+    /// > used to get messages out of the inbox, or otherwise keep them
+    /// > out of the user's way, while still making them accessible.
+    Archive,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox is used to hold draft messages -- typically,
+    /// > messages that are being composed but have not yet been sent.  In
+    /// > some server implementations, this might be a virtual mailbox,
+    /// > containing messages from other mailboxes that are marked with
+    /// > the "\Draft" message flag.  Alternatively, this might just be
+    /// > advice that a client put drafts here.
+    Drafts,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox presents all messages marked in some way as
+    /// > "important".  When this special use is supported, it is likely
+    /// > to represent a virtual mailbox collecting messages (from other
+    /// > mailboxes) that are marked with the "\Flagged" message flag.
+    Flagged,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox is where messages deemed to be junk mail are held.
+    /// > Some server implementations might put messages here
+    /// > automatically.  Alternatively, this might just be advice to a
+    /// > client-side spam filter.
+    Junk,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2):
+    ///
+    /// > This mailbox is used to hold copies of messages that have been
+    /// > sent.  Some server implementations might put messages here
+    /// > automatically.  Alternatively, this might just be advice that a
+    /// > client save sent messages here.
+    Sent,
+    /// From [RFC 6154 section 2](https://tools.ietf.org/html/rfc6154#section-2)
+    ///
+    /// > This mailbox is used to hold messages that have been deleted or
+    /// > marked for deletion.  In some server implementations, this might
+    /// > be a virtual mailbox, containing messages from other mailboxes
+    /// > that are marked with the "\Deleted" message flag.
+    /// > Alternatively, this might just be advice that a client that
+    /// > chooses not to use the IMAP "\Deleted" model should use this as
+    /// > its trash location.  In server implementations that strictly
+    /// > expect the IMAP "\Deleted" model, this special use is likely not
+    /// > to be supported.
+    Trash,
     /// A name attribute not defined in [RFC 3501 section 7.2.2](https://tools.ietf.org/html/rfc3501#section-7.2.2)
     /// or any supported extension.
     Extension(Cow<'a, str>),
@@ -752,6 +811,13 @@ impl<'a> NameAttribute<'a> {
             NameAttribute::NoSelect => NameAttribute::NoSelect,
             NameAttribute::Marked => NameAttribute::Marked,
             NameAttribute::Unmarked => NameAttribute::Unmarked,
+            NameAttribute::All => NameAttribute::All,
+            NameAttribute::Archive => NameAttribute::Archive,
+            NameAttribute::Drafts => NameAttribute::Drafts,
+            NameAttribute::Flagged => NameAttribute::Flagged,
+            NameAttribute::Junk => NameAttribute::Junk,
+            NameAttribute::Sent => NameAttribute::Sent,
+            NameAttribute::Trash => NameAttribute::Trash,
             NameAttribute::Extension(s) => NameAttribute::Extension(to_owned_cow(s)),
         }
     }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -807,10 +807,12 @@ pub enum NameAttribute<'a> {
 impl<'a> NameAttribute<'a> {
     pub fn into_owned(self) -> NameAttribute<'static> {
         match self {
+            // RFC 3501
             NameAttribute::NoInferiors => NameAttribute::NoInferiors,
             NameAttribute::NoSelect => NameAttribute::NoSelect,
             NameAttribute::Marked => NameAttribute::Marked,
             NameAttribute::Unmarked => NameAttribute::Unmarked,
+            // RFC 6154
             NameAttribute::All => NameAttribute::All,
             NameAttribute::Archive => NameAttribute::Archive,
             NameAttribute::Drafts => NameAttribute::Drafts,
@@ -818,6 +820,7 @@ impl<'a> NameAttribute<'a> {
             NameAttribute::Junk => NameAttribute::Junk,
             NameAttribute::Sent => NameAttribute::Sent,
             NameAttribute::Trash => NameAttribute::Trash,
+            // Extensions not supported by this crate
             NameAttribute::Extension(s) => NameAttribute::Extension(to_owned_cow(s)),
         }
     }


### PR DESCRIPTION
This change only adds the name attributes from RFC 6154 Special-Use Mailboxes and not any of the other features.

It should now be possible in a client app to identify the spam folder without matching on the name of the mailbox. Matching on the name of the mailbox is not reliable because it might be localized to the user's language.