### PR TITLE
Add support for googles x-gm-labels extension

### DIFF
--- a/imap-proto/src/builders/command.rs
+++ b/imap-proto/src/builders/command.rs
@@ -253,7 +253,7 @@ fn push_attr(cmd: &mut Vec<u8>, attr: Attribute) {
             Attribute::Rfc822Size => "RFC822.SIZE",
             Attribute::Rfc822Text => "RFC822.TEXT",
             Attribute::Uid => "UID",
-            Attribute::XGmLabels => "X-GM-LABELS"
+            Attribute::XGmLabels => "X-GM-LABELS",
         }
         .as_bytes(),
     );

--- a/imap-proto/src/builders/command.rs
+++ b/imap-proto/src/builders/command.rs
@@ -253,6 +253,7 @@ fn push_attr(cmd: &mut Vec<u8>, attr: Attribute) {
             Attribute::Rfc822Size => "RFC822.SIZE",
             Attribute::Rfc822Text => "RFC822.TEXT",
             Attribute::Uid => "UID",
+            Attribute::XGmLabels => "X-GM-LABELS"
         }
         .as_bytes(),
     );

--- a/imap-proto/src/builders/command.rs
+++ b/imap-proto/src/builders/command.rs
@@ -253,7 +253,7 @@ fn push_attr(cmd: &mut Vec<u8>, attr: Attribute) {
             Attribute::Rfc822Size => "RFC822.SIZE",
             Attribute::Rfc822Text => "RFC822.TEXT",
             Attribute::Uid => "UID",
-            Attribute::XGmLabels => "X-GM-LABELS",
+            Attribute::GmailLabels => "X-GM-LABELS",
         }
         .as_bytes(),
     );

--- a/imap-proto/src/parser/gmail.rs
+++ b/imap-proto/src/parser/gmail.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use nom::IResult;
+use nom::branch::alt;
+use nom::bytes::streaming::tag_no_case;
+use nom::sequence::preceded;
+use nom::combinator::map;
+
+use crate::{AttributeValue, MailboxDatum};
+
+use super::core::{parenthesized_list, quoted_utf8};
+use super::rfc3501::flag;
+
+pub(crate) fn x_gm_label_list(i: &[u8]) -> IResult<&[u8], Vec<Cow<str>>> {
+  preceded(
+      tag_no_case("X-GM-LABELS "),
+      parenthesized_list(map(alt((flag, quoted_utf8)), Cow::Borrowed)),
+  )(i)
+}
+
+pub(crate) fn msg_att_x_gm_labels(i: &[u8]) -> IResult<&[u8], AttributeValue> {
+  map(
+    x_gm_label_list,
+    AttributeValue::XGmLabels
+  )(i)
+}
+
+pub(crate) fn mailbox_data_x_gm_labels(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
+  map(
+    x_gm_label_list,
+    MailboxDatum::XGmLabels
+  )(i)
+}
+
+
+#[cfg(test)]
+mod tests {
+  use crate::types::*;
+  #[test]
+  fn test_x_gm_labels() {
+      let env = br#"X-GM-LABELS (\Inbox \Sent Important "Muy Importante") "#;
+      match super::msg_att_x_gm_labels(env) {
+          Ok((_, AttributeValue::XGmLabels(labels))) => {
+            println!("{:?}", labels);
+            assert_eq!(["\\Inbox", "\\Sent", "Important", "Muy Importante"].to_vec(), labels);
+          }
+          rsp => {
+            let e = rsp.unwrap_err();
+            if let nom::Err::Error(i) = &e {
+              println!("{:?}", std::str::from_utf8(i.input));
+            }
+            panic!("unexpected response {:?}", e);
+          },
+      }
+  }
+}

--- a/imap-proto/src/parser/gmail.rs
+++ b/imap-proto/src/parser/gmail.rs
@@ -11,29 +11,29 @@ use crate::{AttributeValue, MailboxDatum};
 use super::core::{parenthesized_list, quoted_utf8};
 use super::rfc3501::flag;
 
-pub(crate) fn x_gm_label_list(i: &[u8]) -> IResult<&[u8], Vec<Cow<str>>> {
+pub(crate) fn gmail_label_list(i: &[u8]) -> IResult<&[u8], Vec<Cow<str>>> {
     preceded(
         tag_no_case("X-GM-LABELS "),
         parenthesized_list(map(alt((flag, quoted_utf8)), Cow::Borrowed)),
     )(i)
 }
 
-pub(crate) fn msg_att_x_gm_labels(i: &[u8]) -> IResult<&[u8], AttributeValue> {
-    map(x_gm_label_list, AttributeValue::XGmLabels)(i)
+pub(crate) fn msg_att_gmail_labels(i: &[u8]) -> IResult<&[u8], AttributeValue> {
+    map(gmail_label_list, AttributeValue::GmailLabels)(i)
 }
 
-pub(crate) fn mailbox_data_x_gm_labels(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
-    map(x_gm_label_list, MailboxDatum::XGmLabels)(i)
+pub(crate) fn mailbox_data_gmail_labels(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
+    map(gmail_label_list, MailboxDatum::GmailLabels)(i)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::types::*;
     #[test]
-    fn test_x_gm_labels() {
+    fn test_gmail_labels() {
         let env = br#"X-GM-LABELS (\Inbox \Sent Important "Muy Importante") "#;
-        match super::msg_att_x_gm_labels(env) {
-            Ok((_, AttributeValue::XGmLabels(labels))) => {
+        match super::msg_att_gmail_labels(env) {
+            Ok((_, AttributeValue::GmailLabels(labels))) => {
                 println!("{:?}", labels);
                 assert_eq!(
                     ["\\Inbox", "\\Sent", "Important", "Muy Importante"].to_vec(),

--- a/imap-proto/src/parser/gmail.rs
+++ b/imap-proto/src/parser/gmail.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use nom::IResult;
 use nom::branch::alt;
 use nom::bytes::streaming::tag_no_case;
-use nom::sequence::preceded;
 use nom::combinator::map;
+use nom::sequence::preceded;
+use nom::IResult;
 
 use crate::{AttributeValue, MailboxDatum};
 
@@ -12,45 +12,41 @@ use super::core::{parenthesized_list, quoted_utf8};
 use super::rfc3501::flag;
 
 pub(crate) fn x_gm_label_list(i: &[u8]) -> IResult<&[u8], Vec<Cow<str>>> {
-  preceded(
-      tag_no_case("X-GM-LABELS "),
-      parenthesized_list(map(alt((flag, quoted_utf8)), Cow::Borrowed)),
-  )(i)
+    preceded(
+        tag_no_case("X-GM-LABELS "),
+        parenthesized_list(map(alt((flag, quoted_utf8)), Cow::Borrowed)),
+    )(i)
 }
 
 pub(crate) fn msg_att_x_gm_labels(i: &[u8]) -> IResult<&[u8], AttributeValue> {
-  map(
-    x_gm_label_list,
-    AttributeValue::XGmLabels
-  )(i)
+    map(x_gm_label_list, AttributeValue::XGmLabels)(i)
 }
 
 pub(crate) fn mailbox_data_x_gm_labels(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
-  map(
-    x_gm_label_list,
-    MailboxDatum::XGmLabels
-  )(i)
+    map(x_gm_label_list, MailboxDatum::XGmLabels)(i)
 }
-
 
 #[cfg(test)]
 mod tests {
-  use crate::types::*;
-  #[test]
-  fn test_x_gm_labels() {
-      let env = br#"X-GM-LABELS (\Inbox \Sent Important "Muy Importante") "#;
-      match super::msg_att_x_gm_labels(env) {
-          Ok((_, AttributeValue::XGmLabels(labels))) => {
-            println!("{:?}", labels);
-            assert_eq!(["\\Inbox", "\\Sent", "Important", "Muy Importante"].to_vec(), labels);
-          }
-          rsp => {
-            let e = rsp.unwrap_err();
-            if let nom::Err::Error(i) = &e {
-              println!("{:?}", std::str::from_utf8(i.input));
+    use crate::types::*;
+    #[test]
+    fn test_x_gm_labels() {
+        let env = br#"X-GM-LABELS (\Inbox \Sent Important "Muy Importante") "#;
+        match super::msg_att_x_gm_labels(env) {
+            Ok((_, AttributeValue::XGmLabels(labels))) => {
+                println!("{:?}", labels);
+                assert_eq!(
+                    ["\\Inbox", "\\Sent", "Important", "Muy Importante"].to_vec(),
+                    labels
+                );
             }
-            panic!("unexpected response {:?}", e);
-          },
-      }
-  }
+            rsp => {
+                let e = rsp.unwrap_err();
+                if let nom::Err::Error(i) = &e {
+                    println!("{:?}", std::str::from_utf8(i.input));
+                }
+                panic!("unexpected response {:?}", e);
+            }
+        }
+    }
 }

--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -4,6 +4,7 @@ use nom::{branch::alt, IResult};
 pub mod core;
 
 pub mod bodystructure;
+pub mod gmail;
 pub mod rfc2087;
 pub mod rfc3501;
 pub mod rfc4315;
@@ -12,7 +13,6 @@ pub mod rfc5161;
 pub mod rfc5256;
 pub mod rfc5464;
 pub mod rfc7162;
-pub mod gmail;
 
 #[cfg(test)]
 mod tests;

--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -12,6 +12,7 @@ pub mod rfc5161;
 pub mod rfc5256;
 pub mod rfc5464;
 pub mod rfc7162;
+pub mod gmail;
 
 #[cfg(test)]
 mod tests;

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -25,6 +25,8 @@ use crate::{
     types::*,
 };
 
+use super::gmail;
+
 pub mod body;
 pub mod body_structure;
 
@@ -62,14 +64,14 @@ fn mailbox(i: &[u8]) -> IResult<&[u8], &str> {
     })(i)
 }
 
-fn flag_extension(i: &[u8]) -> IResult<&[u8], &str> {
+pub(crate) fn flag_extension(i: &[u8]) -> IResult<&[u8], &str> {
     map_res(
         recognize(pair(tag(b"\\"), take_while(is_atom_char))),
         from_utf8,
     )(i)
 }
 
-fn flag(i: &[u8]) -> IResult<&[u8], &str> {
+pub(crate) fn flag(i: &[u8]) -> IResult<&[u8], &str> {
     alt((flag_extension, atom))(i)
 }
 
@@ -361,6 +363,7 @@ fn mailbox_data(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
         mailbox_data_status,
         mailbox_data_recent,
         mailbox_data_search,
+        gmail::mailbox_data_x_gm_labels,
         rfc5256::mailbox_data_sort,
     ))(i)
 }
@@ -555,6 +558,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue> {
         msg_att_rfc822_size,
         msg_att_rfc822_text,
         msg_att_uid,
+        gmail::msg_att_x_gm_labels
     ))(i)
 }
 

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -64,7 +64,7 @@ fn mailbox(i: &[u8]) -> IResult<&[u8], &str> {
     })(i)
 }
 
-pub(crate) fn flag_extension(i: &[u8]) -> IResult<&[u8], &str> {
+fn flag_extension(i: &[u8]) -> IResult<&[u8], &str> {
     map_res(
         recognize(pair(tag(b"\\"), take_while(is_atom_char))),
         from_utf8,
@@ -363,7 +363,7 @@ fn mailbox_data(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
         mailbox_data_status,
         mailbox_data_recent,
         mailbox_data_search,
-        gmail::mailbox_data_x_gm_labels,
+        gmail::mailbox_data_gmail_labels,
         rfc5256::mailbox_data_sort,
     ))(i)
 }
@@ -558,7 +558,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue> {
         msg_att_rfc822_size,
         msg_att_rfc822_text,
         msg_att_uid,
-        gmail::msg_att_x_gm_labels,
+        gmail::msg_att_gmail_labels,
     ))(i)
 }
 

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -558,7 +558,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue> {
         msg_att_rfc822_size,
         msg_att_rfc822_text,
         msg_att_uid,
-        gmail::msg_att_x_gm_labels
+        gmail::msg_att_x_gm_labels,
     ))(i)
 }
 

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -220,7 +220,7 @@ pub enum MailboxDatum<'a> {
         mailbox: Cow<'a, str>,
         values: Vec<Cow<'a, str>>,
     },
-    XGmLabels(Vec<Cow<'a, str>>),
+    GmailLabels(Vec<Cow<'a, str>>),
 }
 
 impl<'a> MailboxDatum<'a> {
@@ -261,8 +261,8 @@ impl<'a> MailboxDatum<'a> {
                     values: values.into_iter().map(to_owned_cow).collect(),
                 }
             }
-            MailboxDatum::XGmLabels(labels) => {
-                MailboxDatum::XGmLabels(labels.into_iter().map(to_owned_cow).collect())
+            MailboxDatum::GmailLabels(labels) => {
+                MailboxDatum::GmailLabels(labels.into_iter().map(to_owned_cow).collect())
             }
         }
     }
@@ -297,7 +297,8 @@ pub enum Attribute {
     Rfc822Size,
     Rfc822Text,
     Uid,
-    XGmLabels,
+    /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
+    GmailLabels,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -332,7 +333,8 @@ pub enum AttributeValue<'a> {
     Rfc822Size(u32),
     Rfc822Text(Option<Cow<'a, [u8]>>),
     Uid(u32),
-    XGmLabels(Vec<Cow<'a, str>>),
+    /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
+    GmailLabels(Vec<Cow<'a, str>>),
 }
 
 impl<'a> AttributeValue<'a> {
@@ -359,8 +361,8 @@ impl<'a> AttributeValue<'a> {
             AttributeValue::Rfc822Size(v) => AttributeValue::Rfc822Size(v),
             AttributeValue::Rfc822Text(v) => AttributeValue::Rfc822Text(v.map(to_owned_cow)),
             AttributeValue::Uid(v) => AttributeValue::Uid(v),
-            AttributeValue::XGmLabels(v) => {
-                AttributeValue::XGmLabels(v.into_iter().map(to_owned_cow).collect())
+            AttributeValue::GmailLabels(v) => {
+                AttributeValue::GmailLabels(v.into_iter().map(to_owned_cow).collect())
             }
         }
     }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -220,6 +220,7 @@ pub enum MailboxDatum<'a> {
         mailbox: Cow<'a, str>,
         values: Vec<Cow<'a, str>>,
     },
+    XGmLabels(Vec<Cow<'a, str>>),
 }
 
 impl<'a> MailboxDatum<'a> {
@@ -260,6 +261,9 @@ impl<'a> MailboxDatum<'a> {
                     values: values.into_iter().map(to_owned_cow).collect(),
                 }
             }
+            MailboxDatum::XGmLabels(labels) => {
+                MailboxDatum::XGmLabels(labels.into_iter().map(to_owned_cow).collect())
+            }
         }
     }
 }
@@ -293,6 +297,7 @@ pub enum Attribute {
     Rfc822Size,
     Rfc822Text,
     Uid,
+    XGmLabels,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -327,6 +332,7 @@ pub enum AttributeValue<'a> {
     Rfc822Size(u32),
     Rfc822Text(Option<Cow<'a, [u8]>>),
     Uid(u32),
+    XGmLabels(Vec<Cow<'a, str>>),
 }
 
 impl<'a> AttributeValue<'a> {
@@ -353,6 +359,9 @@ impl<'a> AttributeValue<'a> {
             AttributeValue::Rfc822Size(v) => AttributeValue::Rfc822Size(v),
             AttributeValue::Rfc822Text(v) => AttributeValue::Rfc822Text(v.map(to_owned_cow)),
             AttributeValue::Uid(v) => AttributeValue::Uid(v),
+            AttributeValue::XGmLabels(v) => {
+                AttributeValue::XGmLabels(v.into_iter().map(to_owned_cow).collect())
+            }
         }
     }
 }


### PR DESCRIPTION
Followup of https://github.com/djc/tokio-imap/pull/137 with `cargo fmt` commit.