### PR TITLE
add support for RFC2971 IMAP4 ID extension in imap-proto

### DIFF
--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -13,6 +13,7 @@ pub mod rfc5161;
 pub mod rfc5256;
 pub mod rfc5464;
 pub mod rfc7162;
+pub mod rfc2971;
 
 #[cfg(test)]
 mod tests;

--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -6,6 +6,7 @@ pub mod core;
 pub mod bodystructure;
 pub mod gmail;
 pub mod rfc2087;
+pub mod rfc2971;
 pub mod rfc3501;
 pub mod rfc4315;
 pub mod rfc4551;
@@ -13,7 +14,6 @@ pub mod rfc5161;
 pub mod rfc5256;
 pub mod rfc5464;
 pub mod rfc7162;
-pub mod rfc2971;
 
 #[cfg(test)]
 mod tests;

--- a/imap-proto/src/parser/rfc2971.rs
+++ b/imap-proto/src/parser/rfc2971.rs
@@ -1,0 +1,193 @@
+//!
+//!
+//! https://tools.ietf.org/html/rfc2971
+//!
+//! The IMAP4 ID extension
+//!
+
+
+use std::{
+    collections::HashMap,
+    borrow::Cow,
+};
+
+use nom::{
+    IResult,
+    branch::alt,
+    bytes::complete::tag_no_case,
+    character::complete::{char, space1},
+    combinator::map,
+    multi::many0,
+    sequence::{separated_pair, tuple},
+};
+
+use crate::{
+    Response,
+    parser::core::{nil, nstring_utf8, string_utf8},
+};
+
+// A single id parameter (field and value).
+// Format: string SPACE nstring
+// [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
+fn id_param(i: &[u8]) -> IResult<&[u8], (&str, Option<&str>)> {
+    separated_pair(string_utf8, space1, nstring_utf8)(i)
+}
+
+// The non-nil case of id parameter list.
+// Format: "(" #(string SPACE nstring) ")"
+// [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
+fn id_param_list_not_nil(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
+    map(
+        tuple((
+            char('('),
+            id_param,
+            many0(tuple((space1, id_param))),
+            char(')'),
+        )),
+        |(_, first_param, rest_params, _)| {
+            let mut params = vec![first_param];
+            for (_, p) in rest_params {
+                params.push(p)
+            }
+
+            params
+                .into_iter()
+                .filter(|(_k, v)| v.is_some())
+                .map(|(k, v)| (k, v.unwrap()))
+                .collect()
+        },
+    )(i)
+}
+
+// The id parameter list of all cases
+// id_params_list ::= "(" #(string SPACE nstring) ")" / nil
+// [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
+fn id_param_list(i: &[u8]) -> IResult<&[u8], Option<HashMap<&str, &str>>> {
+    alt((
+        map(id_param_list_not_nil, Some),
+        map(nil, |_| None),
+    ))(i)
+}
+
+// id_response ::= "ID" SPACE id_params_list
+// [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
+pub(crate) fn resp_id(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, map) = map(
+        tuple((
+            tag_no_case("ID"),
+            space1,
+            id_param_list,
+        )),
+        |(_id, _sp, p)| p,
+    )(i)?;
+
+    Ok((
+        rest,
+        Response::Id(map.map(|m|
+            m
+                .into_iter()
+                .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
+                .collect()
+        )),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn test_id_param() {
+        assert_matches!(
+            id_param(br##""name" "Cyrus""##),
+            Ok((_, (name, value))) => {
+                assert_eq!(name, "name");
+                assert_eq!(value, Some("Cyrus"));
+            }
+        );
+
+        assert_matches!(
+            id_param(br##""name" NIL"##),
+            Ok((_, (name, value))) => {
+                assert_eq!(name, "name");
+                assert_eq!(value, None);
+            }
+        );
+    }
+
+    #[test]
+    fn test_id_param_list_not_nil() {
+        assert_matches!(
+            id_param_list_not_nil(br##"("name" "Cyrus" "version" "1.5" "os" "sunos" "os-version" "5.5" "support-url" "mailto:cyrus-bugs+@andrew.cmu.edu")"##),
+            Ok((_, params)) => {
+                assert_eq!(
+                    params,
+                    vec![
+                        ("name", "Cyrus"),
+                        ("version", "1.5"),
+                        ("os", "sunos"),
+                        ("os-version", "5.5"),
+                        ("support-url", "mailto:cyrus-bugs+@andrew.cmu.edu"),
+                    ].into_iter()
+                    .collect()
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_id_param_list() {
+        assert_matches!(
+            id_param_list(br##"("name" "Cyrus" "version" "1.5" "os" "sunos" "os-version" "5.5" "support-url" "mailto:cyrus-bugs+@andrew.cmu.edu")"##),
+            Ok((_, Some(params))) => {
+                assert_eq!(
+                    params,
+                    vec![
+                        ("name", "Cyrus"),
+                        ("version", "1.5"),
+                        ("os", "sunos"),
+                        ("os-version", "5.5"),
+                        ("support-url", "mailto:cyrus-bugs+@andrew.cmu.edu"),
+                    ].into_iter()
+                    .collect()
+                );
+            }
+        );
+
+        assert_matches!(
+            id_param_list(br##"NIL"##),
+            Ok((_, params)) => {
+                assert_eq!(params, None);
+            }
+        );
+    }
+
+    #[test]
+    fn test_resp_id() {
+        assert_matches!(
+            resp_id(br##"ID ("name" "Cyrus" "version" "1.5" "os" "sunos" "os-version" "5.5" "support-url" "mailto:cyrus-bugs+@andrew.cmu.edu")"##),
+            Ok((_, Response::Id(Some(id_info)))) => {
+                assert_eq!(
+                    id_info,
+                    vec![
+                        ("name", "Cyrus"),
+                        ("version", "1.5"),
+                        ("os", "sunos"),
+                        ("os-version", "5.5"),
+                        ("support-url", "mailto:cyrus-bugs+@andrew.cmu.edu"),
+                    ].into_iter()
+                    .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
+                    .collect()
+                );
+            }
+        );
+
+        assert_matches!(
+            resp_id(br##"ID NIL"##),
+            Ok((_, Response::Id(id_info))) => {
+                assert_eq!(id_info, None);
+            }
+        );
+    }
+}

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -20,7 +20,7 @@ use nom::{
 use crate::{
     parser::{
         core::*, rfc2087, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551, rfc5161,
-        rfc5256, rfc5464, rfc7162,
+        rfc5256, rfc5464, rfc7162, rfc2971
     },
     types::*,
 };
@@ -679,6 +679,7 @@ pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
             rfc7162::resp_vanished,
             rfc2087::quota,
             rfc2087::quota_root,
+            rfc2971::resp_id,
         )),
         tag(b"\r\n"),
     )(i)

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -19,8 +19,8 @@ use nom::{
 
 use crate::{
     parser::{
-        core::*, rfc2087, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551, rfc5161,
-        rfc5256, rfc5464, rfc7162, rfc2971
+        core::*, rfc2087, rfc2971, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551,
+        rfc5161, rfc5256, rfc5464, rfc7162,
     },
     types::*,
 };

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -93,14 +93,11 @@ impl<'a> Response<'a> {
             Response::MailboxData(datum) => Response::MailboxData(datum.into_owned()),
             Response::Quota(quota) => Response::Quota(quota.into_owned()),
             Response::QuotaRoot(quota_root) => Response::QuotaRoot(quota_root.into_owned()),
-            Response::Id(map) => Response::Id(
-                map.map(|m|
-                    m
-                        .into_iter()
-                        .map(|(k, v)| (to_owned_cow(k), to_owned_cow(v)))
-                        .collect()
-                )
-            ),
+            Response::Id(map) => Response::Id(map.map(|m| {
+                m.into_iter()
+                    .map(|(k, v)| (to_owned_cow(k), to_owned_cow(v)))
+                    .collect()
+            })),
         }
     }
 }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
 fn to_owned_cow<'a, T: ?Sized + ToOwned>(c: Cow<'a, T>) -> Cow<'static, T> {
@@ -43,6 +44,7 @@ pub enum Response<'a> {
     MailboxData(MailboxDatum<'a>),
     Quota(Quota<'a>),
     QuotaRoot(QuotaRoot<'a>),
+    Id(Option<HashMap<Cow<'a, str>, Cow<'a, str>>>),
 }
 
 impl<'a> Response<'a> {
@@ -91,6 +93,14 @@ impl<'a> Response<'a> {
             Response::MailboxData(datum) => Response::MailboxData(datum.into_owned()),
             Response::Quota(quota) => Response::Quota(quota.into_owned()),
             Response::QuotaRoot(quota_root) => Response::QuotaRoot(quota_root.into_owned()),
+            Response::Id(map) => Response::Id(
+                map.map(|m|
+                    m
+                        .into_iter()
+                        .map(|(k, v)| (to_owned_cow(k), to_owned_cow(v)))
+                        .collect()
+                )
+            ),
         }
     }
 }


### PR DESCRIPTION
Hi,
It will be nice to have RFC2971 IMAP4 ID extension supported. I tried to add the code for it. Please help review and see if the code is ok to merge.
Thank you very much!