### PR TITLE
Add support for RFC 4314/2086 ACL extension to imap-proto

### DIFF
--- a/imap-proto/src/parser/mod.rs
+++ b/imap-proto/src/parser/mod.rs
@@ -8,6 +8,7 @@ pub mod gmail;
 pub mod rfc2087;
 pub mod rfc2971;
 pub mod rfc3501;
+pub mod rfc4314;
 pub mod rfc4315;
 pub mod rfc4551;
 pub mod rfc5161;

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -19,8 +19,8 @@ use nom::{
 
 use crate::{
     parser::{
-        core::*, rfc2087, rfc2971, rfc3501::body::*, rfc3501::body_structure::*, rfc4315, rfc4551,
-        rfc5161, rfc5256, rfc5464, rfc7162,
+        core::*, rfc2087, rfc2971, rfc3501::body::*, rfc3501::body_structure::*, rfc4314, rfc4315,
+        rfc4551, rfc5161, rfc5256, rfc5464, rfc7162,
     },
     types::*,
 };
@@ -54,7 +54,7 @@ fn status(i: &[u8]) -> IResult<&[u8], Status> {
     alt((status_ok, status_no, status_bad, status_preauth, status_bye))(i)
 }
 
-fn mailbox(i: &[u8]) -> IResult<&[u8], &str> {
+pub(crate) fn mailbox(i: &[u8]) -> IResult<&[u8], &str> {
     map(astring_utf8, |s| {
         if s.eq_ignore_ascii_case("INBOX") {
             "INBOX"
@@ -680,6 +680,9 @@ pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
             rfc2087::quota,
             rfc2087::quota_root,
             rfc2971::resp_id,
+            rfc4314::acl,
+            rfc4314::list_rights,
+            rfc4314::my_rights,
         )),
         tag(b"\r\n"),
     )(i)

--- a/imap-proto/src/parser/rfc4314.rs
+++ b/imap-proto/src/parser/rfc4314.rs
@@ -1,0 +1,119 @@
+//!
+//! Current
+//! https://tools.ietf.org/html/rfc4314
+//!
+//! Original
+//! https://tools.ietf.org/html/rfc2086
+//!
+//! The IMAP ACL Extension
+//!
+
+use std::borrow::Cow;
+
+use nom::{
+    bytes::streaming::tag_no_case,
+    character::complete::{space0, space1},
+    combinator::map,
+    multi::separated_list0,
+    sequence::{preceded, separated_pair, tuple},
+    IResult,
+};
+
+use crate::parser::core::astring_utf8;
+use crate::parser::rfc3501::mailbox;
+use crate::types::*;
+
+/// 3.6. ACL Response
+/// ```ignore
+/// acl_response  ::= "ACL" SP mailbox SP acl_list
+/// ```
+pub(crate) fn acl(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, _, mailbox, acls)) = tuple((
+        tag_no_case("ACL"),
+        space1,
+        map(mailbox, Cow::Borrowed),
+        acl_list,
+    ))(i)?;
+
+    Ok((rest, Response::Acl(Acl { mailbox, acls })))
+}
+
+/// ```ignore
+/// acl_list  ::= *(SP acl_entry)
+/// ```
+fn acl_list(i: &[u8]) -> IResult<&[u8], Vec<AclEntry>> {
+    preceded(space0, separated_list0(space1, acl_entry))(i)
+}
+
+/// ```ignore
+/// acl_entry ::= SP identifier SP rights
+/// ```
+fn acl_entry(i: &[u8]) -> IResult<&[u8], AclEntry> {
+    let (rest, (identifier, rights)) = separated_pair(
+        map(astring_utf8, Cow::Borrowed),
+        space1,
+        map(astring_utf8, map_text_to_rights),
+    )(i)?;
+
+    Ok((rest, AclEntry { identifier, rights }))
+}
+
+/// 3.7. LISTRIGHTS Response
+/// ```ignore
+/// list_rights_response  ::= "LISTRIGHTS" SP mailbox SP identifier SP required_rights *(SP optional_rights)
+/// ```
+pub(crate) fn list_rights(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, _, mailbox, _, identifier, _, required, optional)) = tuple((
+        tag_no_case("LISTRIGHTS"),
+        space1,
+        map(mailbox, Cow::Borrowed),
+        space1,
+        map(astring_utf8, Cow::Borrowed),
+        space1,
+        map(astring_utf8, map_text_to_rights),
+        list_rights_optional,
+    ))(i)?;
+
+    Ok((
+        rest,
+        Response::ListRights(ListRights {
+            mailbox,
+            identifier,
+            required,
+            optional,
+        }),
+    ))
+}
+
+fn list_rights_optional(i: &[u8]) -> IResult<&[u8], Vec<AclRight>> {
+    let (rest, items) = preceded(space0, separated_list0(space1, astring_utf8))(i)?;
+
+    Ok((
+        rest,
+        items
+            .into_iter()
+            .flat_map(|s| s.chars().map(|c| c.into()))
+            .collect(),
+    ))
+}
+
+/// 3.7. MYRIGHTS Response
+/// ```ignore
+/// my_rights_response  ::= "MYRIGHTS" SP mailbox SP rights
+/// ```
+pub(crate) fn my_rights(i: &[u8]) -> IResult<&[u8], Response> {
+    let (rest, (_, _, mailbox, _, rights)) = tuple((
+        tag_no_case("MYRIGHTS"),
+        space1,
+        map(mailbox, Cow::Borrowed),
+        space1,
+        map(astring_utf8, map_text_to_rights),
+    ))(i)?;
+
+    Ok((rest, Response::MyRights(MyRights { mailbox, rights })))
+}
+
+/// helper routine to map a string to a vec of AclRights
+fn map_text_to_rights(i: &str) -> Vec<AclRight> {
+    i.chars().map(|c| c.into()).collect()
+}

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
+pub mod acls;
+pub use acls::*;
+
 fn to_owned_cow<'a, T: ?Sized + ToOwned>(c: Cow<'a, T>) -> Cow<'static, T> {
     Cow::Owned(c.into_owned())
 }
@@ -45,6 +48,9 @@ pub enum Response<'a> {
     Quota(Quota<'a>),
     QuotaRoot(QuotaRoot<'a>),
     Id(Option<HashMap<Cow<'a, str>, Cow<'a, str>>>),
+    Acl(Acl<'a>),
+    ListRights(ListRights<'a>),
+    MyRights(MyRights<'a>),
 }
 
 impl<'a> Response<'a> {
@@ -98,6 +104,9 @@ impl<'a> Response<'a> {
                     .map(|(k, v)| (to_owned_cow(k), to_owned_cow(v)))
                     .collect()
             })),
+            Response::Acl(acl_list) => Response::Acl(acl_list.into_owned()),
+            Response::ListRights(rights) => Response::ListRights(rights.into_owned()),
+            Response::MyRights(rights) => Response::MyRights(rights.into_owned()),
         }
     }
 }

--- a/imap-proto/src/types/acls.rs
+++ b/imap-proto/src/types/acls.rs
@@ -1,0 +1,177 @@
+use super::to_owned_cow;
+
+use std::borrow::Cow;
+
+// IMAP4 ACL Extension 4313/2086
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Acl<'a> {
+    pub mailbox: Cow<'a, str>,
+    pub acls: Vec<AclEntry<'a>>,
+}
+
+impl<'a> Acl<'a> {
+    pub fn into_owned(self) -> Acl<'static> {
+        Acl {
+            mailbox: to_owned_cow(self.mailbox),
+            acls: self.acls.into_iter().map(AclEntry::into_owned).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct AclEntry<'a> {
+    pub identifier: Cow<'a, str>,
+    pub rights: Vec<AclRight>,
+}
+
+impl<'a> AclEntry<'a> {
+    pub fn into_owned(self) -> AclEntry<'static> {
+        AclEntry {
+            identifier: to_owned_cow(self.identifier),
+            rights: self.rights,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ListRights<'a> {
+    pub mailbox: Cow<'a, str>,
+    pub identifier: Cow<'a, str>,
+    pub required: Vec<AclRight>,
+    pub optional: Vec<AclRight>,
+}
+
+impl<'a> ListRights<'a> {
+    pub fn into_owned(self) -> ListRights<'static> {
+        ListRights {
+            mailbox: to_owned_cow(self.mailbox),
+            identifier: to_owned_cow(self.identifier),
+            required: self.required,
+            optional: self.optional,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct MyRights<'a> {
+    pub mailbox: Cow<'a, str>,
+    pub rights: Vec<AclRight>,
+}
+
+impl<'a> MyRights<'a> {
+    pub fn into_owned(self) -> MyRights<'static> {
+        MyRights {
+            mailbox: to_owned_cow(self.mailbox),
+            rights: self.rights,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum AclRight {
+    /// l - lookup (mailbox is visible to LIST/LSUB commands, SUBSCRIBE
+    /// mailbox)
+    Lookup,
+    /// r - read (SELECT the mailbox, perform STATUS)
+    Read,
+    /// s - keep seen/unseen information across sessions (set or clear
+    /// \SEEN flag via STORE, also set \SEEN during APPEND/COPY/
+    /// FETCH BODY[...])
+    Seen,
+    /// w - write (set or clear flags other than \SEEN and \DELETED via
+    /// STORE, also set them during APPEND/COPY)
+    Write,
+    /// i - insert (perform APPEND, COPY into mailbox)
+    Insert,
+    /// p - post (send mail to submission address for mailbox,
+    /// not enforced by IMAP4 itself)
+    Post,
+    /// k - create mailboxes (CREATE new sub-mailboxes in any
+    /// implementation-defined hierarchy, parent mailbox for the new
+    /// mailbox name in RENAME)
+    CreateMailbox,
+    /// x - delete mailbox (DELETE mailbox, old mailbox name in RENAME)
+    DeleteMailbox,
+    /// t - delete messages (set or clear \DELETED flag via STORE, set
+    /// \DELETED flag during APPEND/COPY)
+    DeleteMessage,
+    /// e - perform EXPUNGE and expunge as a part of CLOSE
+    Expunge,
+    /// a - administer (perform SETACL/DELETEACL/GETACL/LISTRIGHTS)
+    Administer,
+    /// n - ability to write .shared annotations values
+    /// From RFC 5257
+    Annotation,
+    /// c - old (deprecated) create. Do not use. Read RFC 4314 for more information.
+    OldCreate,
+    /// d - old (deprecated) delete. Do not use. Read RFC 4314 for more information.
+    OldDelete,
+    /// A custom right
+    Custom(char),
+}
+
+impl From<char> for AclRight {
+    fn from(c: char) -> Self {
+        match c {
+            'l' => AclRight::Lookup,
+            'r' => AclRight::Read,
+            's' => AclRight::Seen,
+            'w' => AclRight::Write,
+            'i' => AclRight::Insert,
+            'p' => AclRight::Post,
+            'k' => AclRight::CreateMailbox,
+            'x' => AclRight::DeleteMailbox,
+            't' => AclRight::DeleteMessage,
+            'e' => AclRight::Expunge,
+            'a' => AclRight::Administer,
+            'n' => AclRight::Annotation,
+            'c' => AclRight::OldCreate,
+            'd' => AclRight::OldDelete,
+            _ => AclRight::Custom(c),
+        }
+    }
+}
+
+impl From<AclRight> for char {
+    fn from(right: AclRight) -> Self {
+        match right {
+            AclRight::Lookup => 'l',
+            AclRight::Read => 'r',
+            AclRight::Seen => 's',
+            AclRight::Write => 'w',
+            AclRight::Insert => 'i',
+            AclRight::Post => 'p',
+            AclRight::CreateMailbox => 'k',
+            AclRight::DeleteMailbox => 'x',
+            AclRight::DeleteMessage => 't',
+            AclRight::Expunge => 'e',
+            AclRight::Administer => 'a',
+            AclRight::Annotation => 'n',
+            AclRight::OldCreate => 'c',
+            AclRight::OldDelete => 'd',
+            AclRight::Custom(c) => c,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_char_to_acl_right() {
+        assert_eq!(Into::<AclRight>::into('l'), AclRight::Lookup);
+        assert_eq!(Into::<AclRight>::into('c'), AclRight::OldCreate);
+        assert_eq!(Into::<AclRight>::into('k'), AclRight::CreateMailbox);
+        assert_eq!(Into::<AclRight>::into('0'), AclRight::Custom('0'));
+    }
+
+    #[test]
+    fn test_acl_right_to_char() {
+        assert_eq!(Into::<char>::into(AclRight::Lookup), 'l');
+        assert_eq!(Into::<char>::into(AclRight::OldCreate), 'c');
+        assert_eq!(Into::<char>::into(AclRight::CreateMailbox), 'k');
+        assert_eq!(Into::<char>::into(AclRight::Custom('0')), '0');
+    }
+}


### PR DESCRIPTION
Implement parsing of the ACL response types specified in RFC 4314/2086 (and the Annotation right from RFC 5257)

ACL response
LISTRIGHTS response
MYRIGHTS response