### PR TITLE
Add support for google x-gm-msgid extension

### DIFF
--- a/imap-proto/src/builders/command.rs
+++ b/imap-proto/src/builders/command.rs
@@ -254,6 +254,7 @@ fn push_attr(cmd: &mut Vec<u8>, attr: Attribute) {
             Attribute::Rfc822Text => "RFC822.TEXT",
             Attribute::Uid => "UID",
             Attribute::GmailLabels => "X-GM-LABELS",
+            Attribute::GmailMsgId => "X-GM-MSGID",
         }
         .as_bytes(),
     );

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -374,6 +374,7 @@ fn mailbox_data(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
         mailbox_data_recent,
         mailbox_data_search,
         gmail::mailbox_data_gmail_labels,
+        gmail::mailbox_data_gmail_msgid,
         rfc5256::mailbox_data_sort,
     ))(i)
 }
@@ -569,6 +570,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue> {
         msg_att_rfc822_text,
         msg_att_uid,
         gmail::msg_att_gmail_labels,
+        gmail::msg_att_gmail_msgid,
     ))(i)
 }
 

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -237,6 +237,7 @@ pub enum MailboxDatum<'a> {
         values: Vec<Cow<'a, str>>,
     },
     GmailLabels(Vec<Cow<'a, str>>),
+    GmailMsgId(u64),
 }
 
 impl<'a> MailboxDatum<'a> {
@@ -280,6 +281,7 @@ impl<'a> MailboxDatum<'a> {
             MailboxDatum::GmailLabels(labels) => {
                 MailboxDatum::GmailLabels(labels.into_iter().map(to_owned_cow).collect())
             }
+            MailboxDatum::GmailMsgId(msgid) => MailboxDatum::GmailMsgId(msgid),
         }
     }
 }
@@ -315,6 +317,7 @@ pub enum Attribute {
     Uid,
     /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
     GmailLabels,
+    GmailMsgId,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -351,6 +354,7 @@ pub enum AttributeValue<'a> {
     Uid(u32),
     /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
     GmailLabels(Vec<Cow<'a, str>>),
+    GmailMsgId(u64),
 }
 
 impl<'a> AttributeValue<'a> {
@@ -380,6 +384,7 @@ impl<'a> AttributeValue<'a> {
             AttributeValue::GmailLabels(v) => {
                 AttributeValue::GmailLabels(v.into_iter().map(to_owned_cow).collect())
             }
+            AttributeValue::GmailMsgId(v) => AttributeValue::GmailMsgId(v),
         }
     }
 }


### PR DESCRIPTION
Add support for the X-GM-MSGID extension

Gmail provides a unique message ID for each email so that a unique message may be identified across multiple folders.

I made changes similar to https://github.com/djc/tokio-imap/pull/138 and https://github.com/jonhoo/rust-imap/pull/225 then tested that msg ids were correctly fetched from google.