### PR TITLE
fix: allow trailing SP at the end of responses

### DIFF
--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -696,7 +696,10 @@ pub(crate) fn response_data(i: &[u8]) -> IResult<&[u8], Response> {
             rfc4314::list_rights,
             rfc4314::my_rights,
         )),
-        tag(b"\r\n"),
+        preceded(
+            many0(tag(b" ")), // Outlook server sometimes sends whitespace at the end of STATUS response.
+            tag(b"\r\n"),
+        ),
     )(i)
 }
 

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -442,6 +442,15 @@ fn test_status() {
         }
         rsp => panic!("unexpected response {rsp:?}"),
     }
+
+    // Outlook server sends a STATUS response with a space in the end.
+    match parse_response(b"* STATUS Sent (UIDNEXT 107) \r\n") {
+        Ok((_, Response::MailboxData(MailboxDatum::Status { mailbox, status }))) => {
+            assert_eq!(mailbox, "Sent");
+            assert_eq!(status, [StatusAttribute::UidNext(107),]);
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Outlook server sends STATUS responses with a space at the end
even though RFC 3501 formal syntax does not allow it.
