### PR TITLE
removed check for null characters in literal function

### DIFF
--- a/imap-proto/src/parser/core.rs
+++ b/imap-proto/src/parser/core.rs
@@ -98,20 +98,7 @@ pub fn literal(input: &[u8]) -> IResult<&[u8], &[u8]> {
 
     let (remaining, data) = take(count)(remaining)?;
 
-    if !data.iter().all(|byte| is_char8(*byte)) {
-        // FIXME: what ErrorKind should this have?
-        return Err(nom::Err::Error(nom::error::Error::new(
-            remaining,
-            nom::error::ErrorKind::Verify,
-        )));
-    }
-
     Ok((remaining, data))
-}
-
-/// CHAR8 = %x01-ff ; any OCTET except NUL, %x00
-pub fn is_char8(i: u8) -> bool {
-    i != 0
 }
 
 // ----- astring ----- atom (roughly) or string
@@ -280,6 +267,16 @@ mod tests {
         match string(b"{3}\r\nXYZ") {
             Ok((_, value)) => {
                 assert_eq!(value, b"XYZ");
+            }
+            rsp => panic!("unexpected response {rsp:?}"),
+        }
+    }
+
+    #[test]
+    fn test_string_literal_containing_null() {
+        match string(b"{5}\r\nX\0Y\0Z") {
+            Ok((_, value)) => {
+                assert_eq!(value, b"X\0Y\0Z");
             }
             rsp => panic!("unexpected response {rsp:?}"),
         }


### PR DESCRIPTION
Hi - I am developing an app using rust-imap to get emails.

I implemented a full mailbox sync for my clients mailbox and started running it, after a few thousand mails in I got a crash. I started investigating and I tracked down the culprit all the way to these lines. 
If I remove them it works.

What the lines did was that they throw an error if there is a null chracter somewhere in the email.

Now let me explain: What my client has in his mailbox is a corrupted mail that contains a binary within it. 
That cetainly does not meet any standars - however, in practice its bound to be encountered. 
My AST parsers and sanitizers that are run after that handle the mess just fine and delete it as is propper, leaving the base message readable, just like it is readable in Thunderbird and webmailers. 
Without the checker it works just fine, and it is an unnecessary crash  that does not reflect real world data.

The comment said: 
// FIXME: what ErrorKind should this have?
Probably this shouldn't be an error at all.
I am not sure if you are encountering this issue in production, and if this handles genuine cases for you.
But just silent failure is definetly not expected behavior so probably this is pretty rare.

I thought about sanitizing the string in this case but it would hurt performance too much to either make it mutable or allocate a new array here.

So here is my working fix, with food for thought. 

Best!